### PR TITLE
Recommend extending GenericProp for props instead of copying boilerplate

### DIFF
--- a/docs/networkGame/in-3d-screen.md
+++ b/docs/networkGame/in-3d-screen.md
@@ -1,0 +1,58 @@
+---
+title: GUI on a 3D screen
+sidebar_position: 6
+---
+
+# GUI on a 3D screen
+
+To display a 2D interface on an in-world surface — a vehicle dashboard, a control panel, a
+kiosk — render a normal `Control` UI through a `SubViewport` and show it on a mesh via a
+`ViewportTexture`. It can also receive clicks. This is Godot's "GUI in 3D" pattern; the reusable
+helper lives at `scenes/interactables/gui_3d.tscn`.
+
+**Used by**: the mining depot screen (`mining_depot.tscn`) and the vehicle dashboard
+([Adding a vehicle](./vehicles.md)).
+
+## The pieces
+
+- a **UI scene** — a regular `Control` / `Panel` with your labels / buttons (and a script if it
+  needs logic),
+- a **`SubViewport`** holding that UI scene,
+- a **screen `MeshInstance3D`** whose material shows the SubViewport through a `ViewportTexture`,
+- the **`Gui3D`** helper (`scenes/interactables/gui_3d.tscn`) — forwards mouse / touch to the
+  viewport so the UI is clickable (only needed for an interactive screen),
+- (interactive only) an **`Area3D`** over the screen mesh, for the click detection.
+
+## Setup
+
+1. Build the UI scene (Control / Panel + your nodes); attach a script if it has behaviour.
+2. Add a `Gui3D` (instance of `gui_3d.tscn`) where you want the screen, with a child
+   `SubViewport` containing your UI scene, plus the screen mesh.
+3. `SubViewport` → **Update Mode = Always** (otherwise the screen freezes), and set its **Size**
+   to your UI size.
+4. Screen mesh → `StandardMaterial3D`:
+   - **Resource → Local to Scene = On** (required, see below),
+   - **Albedo → Texture → New ViewportTexture → Viewport = this scene's `SubViewport`**,
+   - **Shading = Unshaded** (or use Emission) so it stays readable.
+5. On the `Gui3D`: `node_viewport` = the SubViewport, `node_quad` = the screen mesh, `node_area`
+   = the click `Area3D` (for interactivity).
+
+## Gotchas
+
+:::warning[The screen material must be "Local to Scene"]
+A `ViewportTexture` resolves its viewport per scene instance, so the material holding it (and any
+resource containing it) must have **Local to Scene** enabled — otherwise Godot refuses to create
+the ViewportTexture ("…not local to the scene").
+:::
+
+:::danger[Point the ViewportTexture at THIS scene's SubViewport]
+If you copy a screen from another scene, its `ViewportTexture` keeps the **old** `viewport_path`.
+A path that does not exist in the current scene shows a blank screen and throws
+`common_parent is null` **when you save**. Re-pick the Viewport so it points to this scene's own
+`SubViewport`.
+:::
+
+## Reference
+
+The mining depot (`mining_depot.tscn` → its `Gui3D`) is a complete, working example, including the
+interactive buttons.

--- a/docs/networkGame/player.md
+++ b/docs/networkGame/player.md
@@ -1,0 +1,75 @@
+---
+title: Player network management
+sidebar_position: 2
+---
+
+# Player network management
+
+The player and every generic prop replicate their state to nearby players through the **same**
+mechanism: the game server sends property updates to Horizon, which keeps an authoritative copy
+of each object and forwards the changes to the clients in range.
+
+The only thing **specific to the player** is that it is the entity *your* client controls — it
+sends inputs/actions up to the server. Everything else (how its state reaches the other clients)
+works **exactly like a prop**: see [Props network management](./props.md), which the player
+simply reuses, with its own `player_def.json`.
+
+## Update properties
+
+The player-specific part is the **input/action channel**: the client sends actions up, the
+server applies them and sends results back down.
+
+### Client sends update to server
+
+To update properties or actions from the client to the Godot server, you need to call the function *client_send_action_to_server*.
+
+This is an example for a jump request:
+
+```
+client_send_action_to_server({"action": "jump"})
+```
+
+You can add more than one property in the argument.
+
+### Server receive update
+
+The properties / actions received on the Godot server (can be sent by the client or by a Horizon service), these properties arrive in the function *server_action_received*. You need to manage the key => values.
+
+For example, for the *jump* action received, we have:
+
+```
+func server_action_received(data: Dictionary) -> void:
+match data["action"]:
+"jump":
+is_jumping = true
+```
+
+### Server sends update to client
+
+The server can send updated properties to the client, for example, the health.
+
+To do that, call the function *server_send_properties_to_client*.
+
+For example:
+
+```
+server_send_properties_to_client({"health": 80})
+```
+
+:::warning[Declare the property first]
+`health` will only reach the clients if it is listed in the player definition file
+(`player_def.json`). A property that is not whitelisted there is dropped silently. See
+[Replication definition files](./props.md#replication-definition-files).
+:::
+
+### Client receives update
+
+The client receives all properties modified in the function *client_channel_data_update*, such as the new position and health.
+
+For example:
+
+```
+func client_channel_data_update(data: Dictionary) -> void:
+if data.has("health"):
+health = data["health"]
+```

--- a/docs/networkGame/props.md
+++ b/docs/networkGame/props.md
@@ -1,106 +1,28 @@
 ---
-title: Props and player network management
-sidebar_position: 2
+title: Props network management
+sidebar_position: 3
 ---
 
-# Props and player network management
+# Props network management
 
-The player and every generic prop replicate their state to nearby players through the
-**same** mechanism: the game server sends property updates to Horizon, which keeps an
-authoritative copy of each object and forwards the changes to the clients in range.
+Generic props replicate their state through the same mechanism as the player: the game server
+sends property updates to Horizon, which keeps an authoritative copy and forwards them to the
+clients in range. This page also covers the **player's replication** to other clients — the
+player is just an object of type `player` (with its own `player_def.json`); only its
+input/action channel is specific (see [Player network management](./player.md)).
 
-The only thing **specific to the player** is that it is the entity *your* client controls —
-it sends inputs/actions up to the server. Everything else (how its state reaches the other
-clients) works **exactly like a prop**. So this page covers the player's specifics first,
-then the generic prop mechanism, which the player simply reuses.
+Which properties are actually replicated (and how far / how often) is **not** decided in your
+GDScript: it is declared in a per-type **definition file**. See
+[Replication definition files](#replication-definition-files) below — read it first, because a
+property that is not declared there will silently never reach the clients.
 
-Which properties are actually replicated (and how far / how often) is **not** decided in
-your GDScript: it is declared in a per-type **definition file**. See
-[Replication definition files](#replication-definition-files) below — read
-it first, because a property that is not declared there will silently never reach the
-clients.
-
-## The player
-
-The player is the only object the client **controls**, so the player-specific part is the
-input/action channel: the client sends actions up, the server applies them and sends results
-back down. How the player's resulting state is then replicated to *other* clients is **not**
-special — see [Props](#props) below; the player simply has its own `player_def.json`.
-
-### Update properties
-
-
-#### Client sends update to server
-
-To update properties or actions from the client to the Godot server, you need to call the function *client_send_action_to_server*.
-
-This is an example for a jump request:
-
-```
-client_send_action_to_server({"action": "jump"})
-```
-
-You can add more than one property in the argument.
-
-#### Server receive update
-
-The properties / actions received on the Godot server (can be sent by the client or by a Horizon service), these properties arrive in the function *server_action_received*. You need to manage the key => values.
-
-For example, for the *jump* action received, we have:
-
-```
-func server_action_received(data: Dictionary) -> void:
-match data["action"]:
-"jump":
-is_jumping = true
-```
-
-
-#### Server sends update to client
-
-The server can send updated properties to the client, for example, the health.
-
-To do that, call the function *server_send_properties_to_client*.
-
-For example: 
-
-```
-server_send_properties_to_client({"health": 80})
-```
-
-:::warning[Declare the property first]
-`health` will only reach the clients if it is listed in the player definition file
-(`player_def.json`). A property that is not whitelisted there is dropped silently. See
-[Replication definition files](#replication-definition-files).
-:::
-
-#### Client receives update
-
-The client receives all properties modified in the function *client_channel_data_update*, such as the new position and health.
-
-For example: 
-
-```
-func client_channel_data_update(data: Dictionary) -> void:
-if data.has("health"):
-health = data["health"]
-```
-
-
-## Props
-
-Everything below describes generic props — and it applies to the **player too** for the
-replication of its state to other clients (the player is just an object of type `player`, with
-its own `player_def.json`).
-
-### What is a generic prop?
+## What is a generic prop?
 
 A generic prop is any scene spawned in the game, except for the player scene (*normal_player.tscn*).
 
 It can be a planet, a box, a building, a car...
 
-
-### Writing a generic prop
+## Writing a generic prop
 
 The recommended way is to make your prop **extend `GenericProp`**
 (`scenes/globals/generic_prop.gd`). It already provides everything a networked, carriable
@@ -129,7 +51,7 @@ Build the scene (a body + collision shape + mesh), attach the script, and declar
 `<type>_def.json` (see [Replication definition files](#replication-definition-files)). Done —
 no boilerplate to copy.
 
-#### Complex props
+### Complex props
 
 A prop with special behaviour may stay a standalone script (extending whatever body it needs)
 and implement the contract itself, but it should still call `PropNet.server_tick(self)` from
@@ -137,11 +59,9 @@ its `_physics_process` so replication and carry-follow stay consistent. Example:
 rock (`rock_mining.gd`) is custom because it fractures, and only a **fully-fractured ore
 piece** is carriable (it overrides `interact()` for that) — a whole rock is not carriable.
 
+## Update properties
 
-### Update properties
-
-
-#### Server sends update to client
+### Server sends update to client
 
 The server can send updated properties to the client, for example, a LED state.
 
@@ -162,8 +82,7 @@ has_parent
 In the argument where we have *led*, we can put many properties.
 All other arguments are the same.
 
-
-#### Client receives update
+### Client receives update
 
 The client receives the properties updated by the server in the function *client_channel_data_update*.
 
@@ -175,11 +94,9 @@ You can update or do what you want with the value.
 Be careful, the int value sent by the server is a float when it arrives, so you need to convert it to int before use.
 :::
 
-
-### Delete prop
+## Delete prop
 
 To delete a prop, the function *_exit_tree* sends the signal to the client, and the client deletes the scene; it's automatic!
-
 
 ## Replication definition files
 
@@ -236,7 +153,6 @@ receives the scene **without** its placement and spawns the object at the world 
 `(0,0,0)`. Keep `scenename`, `position` and `parent_id` within the **same** `distance`.
 :::
 
-
 ## Spawning a prop from the game server
 
 If the game server creates a prop at runtime (not through the normal spawn flow), registering
@@ -250,4 +166,3 @@ helper does both:
 ```
 NetworkOrchestrator.spawn_prop_authoritative(data)  # data must hold "uuid" and "type"
 ```
-

--- a/docs/networkGame/props.md
+++ b/docs/networkGame/props.md
@@ -153,6 +153,14 @@ receives the scene **without** its placement and spawns the object at the world 
 `(0,0,0)`. Keep `scenename`, `position` and `parent_id` within the **same** `distance`.
 :::
 
+:::danger[Always declare zone 6 — the deletion channel]
+Object deletion is sent on **channel 6**. Every prop type's def **must** include a `zone 6`
+entry (it carries `scenename`). Without it, deleting the object fails with
+`Channel 6 not defined for object <uuid>`: it is removed server-side and from GORC, but the
+**delete never reaches the clients**, so it stays on screen (a "ghost"). When you add a new
+prop type, copy the `zone 6` block from `box_def.json` / `miningrock_def.json`.
+:::
+
 ## Spawning a prop from the game server
 
 If the game server creates a prop at runtime (not through the normal spawn flow), registering

--- a/docs/networkGame/props.md
+++ b/docs/networkGame/props.md
@@ -96,7 +96,56 @@ Be careful, the int value sent by the server is a float when it arrives, so you 
 
 ## Delete prop
 
-To delete a prop, the function *_exit_tree* sends the signal to the client, and the client deletes the scene; it's automatic!
+Deletion is **server-authoritative**: a prop is removed by freeing its node **on the Godot
+server** — never directly by a client. When the node leaves the tree, its `_exit_tree` emits
+`hs_server_prop_delete` and the rest is automatic:
+
+1. the Godot server sends a `props/delete_object` message to Horizon,
+2. Horizon removes the object from GORC, so every nearby client gets a zone-exit and despawns
+   the scene (the prop disappears for everyone),
+3. Horizon forwards the deletion to the **persistence** service, which removes the row from the
+   database — so the prop does **not** respawn after a restart.
+
+### Triggering a deletion (server side)
+
+Free the prop node on the server — e.g. the mining depot consuming a deposited rock:
+
+```
+func _collect_rock(rock: Node) -> void:
+	rock.queue_free()  # _exit_tree -> hs_server_prop_delete -> GORC + database
+```
+
+### Requesting a deletion from a client
+
+A client never deletes a prop itself: it sends an action (the same channel as any other action,
+see [Player network management](./player.md)); the server validates it and frees the node.
+
+```
+# client
+client_send_action_to_server({"action": "delete_prop", "type": type_name, "uuid": uuid})
+
+# server, in server_action_received(data)
+"delete_prop":
+	var prop := _find_deletable_prop(str(data.get("uuid", "")))
+	if prop != null:
+		prop.queue_free()  # held locally -> _exit_tree replicates the delete
+	else:
+		# Not held as a node by THIS server (e.g. loaded from the database elsewhere): send the
+		# delete message to Horizon directly so it still leaves GORC and the database.
+		_on_prop_delete(str(data.get("uuid", "")), str(data.get("type", "")))
+```
+
+:::note[The delete message vs the trigger]
+What actually deletes the object is the `props/delete_object` message sent to Horizon. Freeing
+the node via `_exit_tree` is just the usual trigger; a server can also send that message directly
+for a prop it does not currently hold as a node.
+:::
+
+:::warning[Database deletion needs the bridge subscription]
+For the deletion to reach the database, the `ds_bridge` persistence service must be subscribed to
+`plugin:genericprops:delete_object` in `plugins.toml`. The Docker config (`.docker/plugins.toml`)
+already is; a bare-metal `plugins.toml` may not be.
+:::
 
 ## Replication definition files
 

--- a/docs/networkGame/props_player.md
+++ b/docs/networkGame/props_player.md
@@ -88,87 +88,42 @@ A generic prop is any scene spawned in the game, except for the player scene (*n
 It can be a planet, a box, a building, a car...
 
 
-### Structure of the gd file
+### Writing a generic prop
 
-For each generic prop scene, it **MUST HAVE A GD SCRIPT ATTACHED**.
+The recommended way is to make your prop **extend `GenericProp`**
+(`scenes/globals/generic_prop.gd`). It already provides everything a networked, carriable
+prop needs:
 
-This GD script must have at a minimum the following data inside (you can copy the content and paste it):
+- the replication signals (`hs_server_prop_update` / `hs_server_prop_delete`),
+- the `uuid` / `type_name` / position state,
+- server -> client replication every physics frame via `PropNet.server_tick(self)` —
+  including **following the carrier** while the prop is held,
+- the `"carriable"` group and the carry contract (`interact()` / `set_carried()`, which also
+  disables the prop's collision while it is carried),
+- reparenting and delete-on-exit.
+
+So a carriable prop is just:
 
 ```
-# TODO Change the class_name
 class_name Box50cm
-
-# TODO Update to the right node
-extends RigidBody3D
-
-signal hs_server_prop_update
-signal hs_server_prop_delete
-
-@export var uuid: String = ""
-
-# TODO change the type
-var type_name = "box"
-
-var spawn_position: Vector3 = Vector3.ZERO
-var spawn_rotation: Vector3 = Vector3.UP
-
-var server_last_position = Vector3.ZERO
-var server_last_rotation = Vector3.ZERO
-
-var has_parent: bool = false
+extends GenericProp
 
 func _ready() -> void:
-	position = spawn_position
-
-func _physics_process(_delta: float) -> void:
-	if GameOrchestrator.is_server():
-    # this part send the position or rotation if changed since last frame
-		var my_position = snapped(position, Vector3(0.001, 0.001, 0.001))
-		var my_rotation = snapped(rotation, Vector3(0.0001, 0.0001, 0.0001))
-		if server_last_position != my_position or server_last_rotation != my_rotation:
-			emit_signal(
-				"hs_server_prop_update",
-				uuid,
-				{
-					"position": my_position,
-					"rotation": my_rotation,
-				},
-				type_name,
-				has_parent
-			)
-			server_last_position = my_position
-			server_last_rotation = my_rotation
-
-func _exit_tree() -> void:
-	if GameOrchestrator.is_server():
-    # send the information to the client the server delete this scene
-		emit_signal(
-			"hs_server_prop_delete",
-			uuid,
-			type_name
-		)
-
-# manage the parent changes
-func client_parent_change(parent: Node) -> void:
-	reparent(parent)
-	has_parent = true
-
-# receive the update from server, in this example, we manage position and rotation properties
-func client_channel_data_update(data: Dictionary) -> void:
-	if data.has("position"):
-		position = Vector3(
-			data["position"]["x"],
-			data["position"]["y"],
-			data["position"]["z"]
-		)
-	if data.has("rotation"):
-		rotation = Vector3(
-			data["rotation"]["x"],
-			data["rotation"]["y"],
-			data["rotation"]["z"]
-		)
-
+	type_name = "box"
+	super()
 ```
+
+Build the scene (a body + collision shape + mesh), attach the script, and declare a
+`<type>_def.json` (see [Replication definition files](#replication-definition-files)). Done —
+no boilerplate to copy.
+
+#### Complex props
+
+A prop with special behaviour may stay a standalone script (extending whatever body it needs)
+and implement the contract itself, but it should still call `PropNet.server_tick(self)` from
+its `_physics_process` so replication and carry-follow stay consistent. Example: the mining
+rock (`rock_mining.gd`) is custom because it fractures, and only a **fully-fractured ore
+piece** is carriable (it overrides `interact()` for that) — a whole rock is not carriable.
 
 
 ### Update properties

--- a/docs/networkGame/props_player.md
+++ b/docs/networkGame/props_player.md
@@ -7,9 +7,12 @@ sidebar_position: 2
 
 The player and every generic prop replicate their state to nearby players through the
 **same** mechanism: the game server sends property updates to Horizon, which keeps an
-authoritative copy of each object and forwards the changes to the clients in range. The
-player is simply an object of type `player` — there is no longer a player-specific update
-path.
+authoritative copy of each object and forwards the changes to the clients in range.
+
+The only thing **specific to the player** is that it is the entity *your* client controls —
+it sends inputs/actions up to the server. Everything else (how its state reaches the other
+clients) works **exactly like a prop**. So this page covers the player's specifics first,
+then the generic prop mechanism, which the player simply reuses.
 
 Which properties are actually replicated (and how far / how often) is **not** decided in
 your GDScript: it is declared in a per-type **definition file**. See
@@ -17,7 +20,12 @@ your GDScript: it is declared in a per-type **definition file**. See
 it first, because a property that is not declared there will silently never reach the
 clients.
 
-## Player management
+## The player
+
+The player is the only object the client **controls**, so the player-specific part is the
+input/action channel: the client sends actions up, the server applies them and sends results
+back down. How the player's resulting state is then replicated to *other* clients is **not**
+special — see [Props](#props) below; the player simply has its own `player_def.json`.
 
 ### Update properties
 
@@ -79,7 +87,11 @@ health = data["health"]
 ```
 
 
-## Generic props management
+## Props
+
+Everything below describes generic props — and it applies to the **player too** for the
+replication of its state to other clients (the player is just an object of type `player`, with
+its own `player_def.json`).
 
 ### What is a generic prop?
 

--- a/docs/networkGame/tools.md
+++ b/docs/networkGame/tools.md
@@ -1,0 +1,80 @@
+---
+title: Adding a tool
+sidebar_position: 5
+---
+
+# Adding a tool
+
+A **tool** is a piece of equipment the player holds and uses — the mining hammer-drill today,
+maybe a welder, scanner or cutter tomorrow.
+
+:::note[No `Tool` base class yet]
+There is currently **one** tool, so there is no formal `Tool` base class. `MiningTool`
+(`scenes/normal_player/mining_tool.gd`) is the **reference implementation**, and the generic,
+reusable piece is the **`EquipmentMount`** (`scenes/normal_player/equipment_mount.gd`). This
+page describes the pattern to follow; copying `MiningTool`'s structure is the fastest start.
+See the [recommendation](#recommendation) at the end about factoring a base class.
+:::
+
+## The pieces
+
+| Piece | Role |
+|---|---|
+| `EquipmentMount` (`equipment_mount.gd`) | Generic hand mount: holds **one** item under the player's hand and orients it (follows the camera pitch, or aims its tip at a world point). Reusable by any tool/weapon — open/closed, you don't touch the items themselves. |
+| The tool node (e.g. `MiningTool`) | A `Node3D` child of the player holding the tool logic: equip/stow, per-frame update, the action, and its networking. |
+| The action channel | How a tool action reaches the server and the other clients — the same client→server channel the player uses (see [Props network management](./props.md)). |
+
+## 1. Where to put the model
+
+Tool models live under `assets/models/equipments/tools/<category>/` (e.g. the drill is
+`assets/models/equipments/tools/mining/hammerdrill.glb`). Follow
+[Files structure](../creativeConcept/files_structure.md) and
+[3D models](../creativeConcept/3d_models.md).
+
+## 2. The tool node
+
+Add a `Node3D`-derived script as a child of the player (like `$MiningTool`), following the
+`MiningTool` shape:
+
+- **`setup(camera_pivot, camera)`** — called from the player's `_ready`: cache the camera, get
+  the `EquipmentMount`, and `hold()` the tool model in it.
+- **`toggle_equip()`** — bound to an input action (the drill uses `toggle_tool`): shows / hides
+  the held model.
+- **`update_local(delta)`** — called each frame for the local player: aim, animate, detect when
+  the action triggers.
+- **State flags the player reads** — e.g. `is_aiming`, `is_perforating`. The player uses them to
+  slow movement and freeze the mouse while aiming / using the tool.
+
+The model is held and oriented by the `EquipmentMount`, placed through exported offsets (hand
+offset, item offset / rotation / scale) — you don't move the model node by hand.
+
+## 3. The tool action (networking)
+
+A tool action is **server-authoritative**, like everything else. The pattern:
+
+1. The local tool emits a **`sync_requested`** signal carrying the action data; the player
+   connects it to `client_send_action_to_server`, so the tool stays decoupled from the socket.
+2. The server receives it in `server_action_received` and applies the effect (the drill
+   fractures the aimed rock).
+3. The equipped tool and its visible state are **replicated as player properties** (the drill
+   uses a `tools` property + the camera `head` pitch) so other clients see you holding and using
+   it. Remote clients apply it through the tool's **`apply_remote(data)`**, and the server sets
+   the equipped tool via **`server_set_tool(...)`**.
+
+:::warning[Whitelist the replicated properties]
+Any property you replicate for the tool (`tools`, `head`, …) must be declared in
+`player_def.json`, or it is dropped silently. See
+[Replication definition files](./props.md#replication-definition-files).
+:::
+
+## 4. Stowing
+
+If the tool must disappear in some states (the drill stows while the player carries an ore),
+expose a **`set_stowed(value)`** and call it from the player when that state changes.
+
+## Recommendation
+
+Because `MiningTool` is the only tool today, equip/stow, the `EquipmentMount` wiring and the
+`sync_requested` plumbing all live in one script. When a second tool arrives, factor those
+shared parts into a small **`Tool` base class** so a new tool only implements its own action —
+the same way [`GenericProp`](./props.md) factors carriable props.

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -131,44 +131,12 @@ the def and **rebuild Horizon**.
 
 ## Dashboard — optional in-cab screen
 
-To show live data (speed, RPM, load…) on a screen in the cab, use Godot's "GUI in 3D" pattern: a
-2D UI is rendered through a `SubViewport` and displayed on a mesh via a `ViewportTexture`. The
-mining depot's screen (`mining_depot.tscn`) is the reference.
+Show live data (speed, RPM, load…) on a screen in the cab using the generic 3D-screen pattern —
+see **[GUI on a 3D screen](./in-3d-screen.md)** for the setup (SubViewport, ViewportTexture, and
+the Local-to-Scene / viewport-path gotchas).
 
-The pieces:
-
-- a **UI scene** (a `Control` / `Panel` with your `Label`s) with `vehicle_dashboard.gd`
-  (`VehicleDashboard`) on its root — it finds its owning `Vehicle` in the tree and shows its data
-  each frame (reusable; the vehicle knows nothing about it),
-- a **`SubViewport`** holding that UI scene,
-- a **screen `MeshInstance3D`** whose material displays the SubViewport via a `ViewportTexture`,
-- `scenes/interactables/gui_3d.tscn` — the reusable helper that forwards mouse/touch to the
-  viewport (only needed once the screen is interactive).
-
-Setup:
-
-1. Build the UI scene (Labels named `speed`, `RPM`, `Load`, `Overloaded`, `Elec_THerm`,
-   `Transmission`, or adjust the names in `vehicle_dashboard.gd`) and put `vehicle_dashboard.gd`
-   on its root.
-2. Under the vehicle, add a `Gui3D` (instance of `gui_3d.tscn`) with a child `SubViewport`
-   containing your UI scene, plus the screen mesh.
-3. `SubViewport` → **Update Mode = Always** (otherwise the screen freezes).
-4. Screen mesh → `StandardMaterial3D`:
-   - **Resource → Local to Scene = On** (required, see below),
-   - **Albedo → Texture → New ViewportTexture → Viewport = this vehicle's `Gui3D/SubViewport`**,
-   - **Shading = Unshaded** (or use Emission) so it stays readable.
-5. On the `Gui3D`: `node_viewport` = the SubViewport, `node_quad` = the screen mesh, `node_area` =
-   the touch `Area3D` (for interactivity).
-
-:::warning[The screen material must be "Local to Scene"]
-A `ViewportTexture` resolves its viewport per scene instance, so the material holding it (and any
-resource containing it) must have **Local to Scene** enabled — otherwise Godot refuses to create
-the ViewportTexture ("…not local to the scene").
-:::
-
-:::danger[Point the ViewportTexture at THIS vehicle's SubViewport]
-If you copy a screen from another scene, its `ViewportTexture` keeps the **old** `viewport_path`
-(e.g. `miningdepot/Gui3D/SubViewport`). A path that does not exist in this scene shows a blank
-screen and throws `common_parent is null` **when you save**. Re-pick the Viewport so it points to
-this vehicle's own `SubViewport`.
-:::
+The **vehicle-specific** part is only the UI script: put `vehicle_dashboard.gd`
+(`VehicleDashboard`) on your UI scene's root. It finds its owning `Vehicle` in the tree and shows
+the generic Vehicle data each frame (speed, RPM, load, overload, powertrain, transmission) — so it
+is reusable by any vehicle, and the Vehicle knows nothing about it. Name the Labels `speed`,
+`RPM`, `Load`, `Overloaded`, `Elec_THerm`, `Transmission` (or adjust them in the script).

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -1,0 +1,130 @@
+---
+title: Adding a vehicle
+sidebar_position: 4
+---
+
+# Adding a vehicle
+
+This guide walks through creating a new drivable vehicle (truck, car, rover…). Vehicles are
+server-authoritative networked props: the game server simulates the physics and replicates the
+state to every client, exactly like the other props (see
+[Props network management](./props.md)). A vehicle adds two things on top:
+**driving** (a powertrain) and **seats** (driver / passengers).
+
+All the moving parts already exist as reusable pieces — in most cases a new vehicle is just a
+**scene** to assemble, not new code.
+
+## The pieces
+
+| Script | Role |
+|---|---|
+| `scenes/vehicles/vehicle.gd` (`class_name Vehicle`) | The vehicle base: body/wheels, physics, driving, networking, cargo. Put it on the scene root. |
+| `scenes/vehicles/vehicle_powertrain.gd` | Engine math (electric / thermal gearbox). Owned by `Vehicle`, configured through its `@export`s — you don't touch it. |
+| `scenes/vehicles/vehicle_seat.gd` (`class_name VehicleSeat`) | One seat zone (driver or passenger). You drop one per seat. |
+| `scenes/vehicles/vehicle_debug_hud.gd` | Optional on-screen dashboard (speed, RPM, load). |
+
+## 1. Where to put the files
+
+- **Scene**: `scenes/vehicles/<category>/<name>.tscn` (e.g. `scenes/vehicles/trucks/truck.tscn`).
+- **Assets** (3D model, materials, textures): follow the project conventions in
+  [Files structure](../creativeConcept/files_structure.md) and
+  [3D models](../creativeConcept/3d_models.md). Do **not** invent a new layout.
+
+## 2. Build the scene
+
+Create a scene whose **root is a `VehicleBody3D`** and attach `vehicle.gd` to it.
+
+You have two options for the body:
+
+- **Real 3D model** — add your `MeshInstance3D` model and a `CollisionShape3D` matching it, as
+  children of the root.
+- **Parametric blockout (placeholder)** — `vehicle.gd` can generate a box-built body, chassis
+  collision, four wheels, cameras and the cargo bay from its exported dimensions (`@tool`, so it
+  rebuilds live in the editor). This is what the truck uses while waiting for the real model.
+  Tune it via the **Body / Cab / Bed / Wheels** export groups, and carve the cab opening with
+  **Cab → Cab Cutout Size / Offset**.
+
+The generated nodes are transient (no owner), so the `.tscn` stays minimal — only the root, its
+script and your designer-placed nodes (the seats below) are saved.
+
+## 3. Add the seats
+
+For each place, add a **`VehicleSeat`** node (an `Area3D` with `vehicle_seat.gd`) as a child of
+the root, then give it two children:
+
+```
+Truck (VehicleBody3D, vehicle.gd)
+├── SeatDriver      (Area3D, vehicle_seat.gd)   role = Driver
+│   ├── CollisionShape3D (BoxShape3D)   ← the "press E here" box, beside the door
+│   └── SitPoint (Marker3D)             ← where the occupant sits (driver: the camera eye)
+└── SeatPassenger   (Area3D, vehicle_seat.gd)   role = Passenger
+    ├── CollisionShape3D (BoxShape3D)
+    └── SitPoint (Marker3D)
+```
+
+- **`role`** (inspector): `Driver` controls the vehicle (drive input + HUD); `Passenger` just
+  rides along. Set this per seat.
+- **The box** (`CollisionShape3D`): size and place it where a player on foot stands to board
+  (e.g. left of the cab for the driver). It is the zone that enables **E**.
+- **`SitPoint`** (`Marker3D`): where the occupant is seated. For the driver it is also the
+  **camera eye**, so place it at head height inside the cab, facing forward (the vehicle's local
+  `-Z`).
+
+You don't wire anything: the `Vehicle` discovers its seats automatically, and each seat
+auto-detects the player (its collision mask is set in code). Standing in a box shows
+`[E] Drive Seat` / `[E] Passenger Seat` at the crosshair; the driver gets free mouse look while
+driving and exits with **Y**.
+
+:::tip[Seats are server-authoritative]
+A seat refuses a second occupant. The driver/passenger logic lives in the **networked** path, so
+test seats in the game (F5), not the standalone bench.
+:::
+
+## 4. Configure the powertrain
+
+On the root `Vehicle`, open the **Drive** export group:
+
+- **Propulsion Type**: `ELECTRIC` (single-speed, instant torque) or `THERMAL` (automatic
+  gearbox). The inspector shows only the relevant sub-group (**Electric** or **Thermal gearbox**).
+- Tune `engine_power`, `max_speed_kmh`, `reverse_max_kmh`, steering, brakes, and the wheel /
+  suspension settings.
+- **Mass** is the standard `RigidBody3D` mass; **Cargo** (`max_payload`, overload) drives the
+  load limiter.
+
+You never edit `vehicle_powertrain.gd` — the `Vehicle` copies these settings into it each frame
+(so you can tune them live while driving the bench).
+
+## 5. Register it on the network
+
+A vehicle only replicates if the network layer knows it:
+
+1. **Spawn registry** — add the scene path to `props_scene` in **both** `server/client.gd` and
+   `server/server.gd`:
+
+   ```
+   'scenes/vehicles/<category>/<name>.tscn':
+       preload('res://scenes/vehicles/<category>/<name>.tscn'),
+   ```
+
+   (These are plain string paths — if you ever **move** the scene, update them by hand; Godot's
+   UID rename does not touch string paths.)
+
+2. **Replication definition** — vehicles use the `vehicle` prop type, defined in
+   `horizonserver/ds_genericprops/props/vehicle_def.json` (whitelisting `position`, `rotation`,
+   `scenename`, `parent_id`, `pilot_uuid`, `steering`). If you reuse the `vehicle` type, there is
+   nothing to add. A brand-new type needs its own `<type>_def.json` — see
+   [Replication definition files](./props.md#replication-definition-files).
+
+:::warning[Rebuild Horizon after touching a def]
+A property (or a whole type) that is not whitelisted is dropped silently → the vehicle appears on
+the server but is **invisible** to clients (`Object definition not found for type: …`). Add it to
+the def and **rebuild Horizon**.
+:::
+
+## 6. Test
+
+- **Bench (F6)** — `scenes/vehicles/vehicle_bench.tscn` drives the vehicle locally (no network):
+  good for tuning the body, suspension and powertrain feel. The bench boards as driver only.
+- **In game (F5)** — the full flow: spawn the vehicle, walk into a seat box, **E** to board as
+  driver or passenger, drive, **Y** to leave. This is the only place seats and passengers are
+  faithful.

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -128,3 +128,47 @@ the def and **rebuild Horizon**.
 - **In game (F5)** — the full flow: spawn the vehicle, walk into a seat box, **E** to board as
   driver or passenger, drive, **Y** to leave. This is the only place seats and passengers are
   faithful.
+
+## Dashboard — optional in-cab screen
+
+To show live data (speed, RPM, load…) on a screen in the cab, use Godot's "GUI in 3D" pattern: a
+2D UI is rendered through a `SubViewport` and displayed on a mesh via a `ViewportTexture`. The
+mining depot's screen (`mining_depot.tscn`) is the reference.
+
+The pieces:
+
+- a **UI scene** (a `Control` / `Panel` with your `Label`s) with `vehicle_dashboard.gd`
+  (`VehicleDashboard`) on its root — it finds its owning `Vehicle` in the tree and shows its data
+  each frame (reusable; the vehicle knows nothing about it),
+- a **`SubViewport`** holding that UI scene,
+- a **screen `MeshInstance3D`** whose material displays the SubViewport via a `ViewportTexture`,
+- `scenes/interactables/gui_3d.tscn` — the reusable helper that forwards mouse/touch to the
+  viewport (only needed once the screen is interactive).
+
+Setup:
+
+1. Build the UI scene (Labels named `speed`, `RPM`, `Load`, `Overloaded`, `Elec_THerm`,
+   `Transmission`, or adjust the names in `vehicle_dashboard.gd`) and put `vehicle_dashboard.gd`
+   on its root.
+2. Under the vehicle, add a `Gui3D` (instance of `gui_3d.tscn`) with a child `SubViewport`
+   containing your UI scene, plus the screen mesh.
+3. `SubViewport` → **Update Mode = Always** (otherwise the screen freezes).
+4. Screen mesh → `StandardMaterial3D`:
+   - **Resource → Local to Scene = On** (required, see below),
+   - **Albedo → Texture → New ViewportTexture → Viewport = this vehicle's `Gui3D/SubViewport`**,
+   - **Shading = Unshaded** (or use Emission) so it stays readable.
+5. On the `Gui3D`: `node_viewport` = the SubViewport, `node_quad` = the screen mesh, `node_area` =
+   the touch `Area3D` (for interactivity).
+
+:::warning[The screen material must be "Local to Scene"]
+A `ViewportTexture` resolves its viewport per scene instance, so the material holding it (and any
+resource containing it) must have **Local to Scene** enabled — otherwise Godot refuses to create
+the ViewportTexture ("…not local to the scene").
+:::
+
+:::danger[Point the ViewportTexture at THIS vehicle's SubViewport]
+If you copy a screen from another scene, its `ViewportTexture` keeps the **old** `viewport_path`
+(e.g. `miningdepot/Gui3D/SubViewport`). A path that does not exist in this scene shows a blank
+screen and throws `common_parent is null` **when you save**. Re-pick the Viewport so it points to
+this vehicle's own `SubViewport`.
+:::


### PR DESCRIPTION
## Description

Replace the "copy this script template" guidance for props with the `GenericProp` base class: a carriable networked prop is just
`extends GenericProp` + its `type_name`. 

Note that complex props (e.g. the mining rock, only carriable once fully fractured) stay custom but should still reuse `PropNet.server_tick`.