### PR TITLE
Docs/adding a vehicle

### DIFF
--- a/docs/networkGame/tools.md
+++ b/docs/networkGame/tools.md
@@ -1,0 +1,80 @@
+---
+title: Adding a tool
+sidebar_position: 4
+---
+
+# Adding a tool
+
+A **tool** is a piece of equipment the player holds and uses — the mining hammer-drill today,
+maybe a welder, scanner or cutter tomorrow.
+
+:::note[No `Tool` base class yet]
+There is currently **one** tool, so there is no formal `Tool` base class. `MiningTool`
+(`scenes/normal_player/mining_tool.gd`) is the **reference implementation**, and the generic,
+reusable piece is the **`EquipmentMount`** (`scenes/normal_player/equipment_mount.gd`). This
+page describes the pattern to follow; copying `MiningTool`'s structure is the fastest start.
+See the [recommendation](#recommendation) at the end about factoring a base class.
+:::
+
+## The pieces
+
+| Piece | Role |
+|---|---|
+| `EquipmentMount` (`equipment_mount.gd`) | Generic hand mount: holds **one** item under the player's hand and orients it (follows the camera pitch, or aims its tip at a world point). Reusable by any tool/weapon — open/closed, you don't touch the items themselves. |
+| The tool node (e.g. `MiningTool`) | A `Node3D` child of the player holding the tool logic: equip/stow, per-frame update, the action, and its networking. |
+| The action channel | How a tool action reaches the server and the other clients — the same client→server channel the player uses (see [Props and player network management](./props_player.md)). |
+
+## 1. Where to put the model
+
+Tool models live under `assets/models/equipments/tools/<category>/` (e.g. the drill is
+`assets/models/equipments/tools/mining/hammerdrill.glb`). Follow
+[Files structure](../creativeConcept/files_structure.md) and
+[3D models](../creativeConcept/3d_models.md).
+
+## 2. The tool node
+
+Add a `Node3D`-derived script as a child of the player (like `$MiningTool`), following the
+`MiningTool` shape:
+
+- **`setup(camera_pivot, camera)`** — called from the player's `_ready`: cache the camera, get
+  the `EquipmentMount`, and `hold()` the tool model in it.
+- **`toggle_equip()`** — bound to an input action (the drill uses `toggle_tool`): shows / hides
+  the held model.
+- **`update_local(delta)`** — called each frame for the local player: aim, animate, detect when
+  the action triggers.
+- **State flags the player reads** — e.g. `is_aiming`, `is_perforating`. The player uses them to
+  slow movement and freeze the mouse while aiming / using the tool.
+
+The model is held and oriented by the `EquipmentMount`, placed through exported offsets (hand
+offset, item offset / rotation / scale) — you don't move the model node by hand.
+
+## 3. The tool action (networking)
+
+A tool action is **server-authoritative**, like everything else. The pattern:
+
+1. The local tool emits a **`sync_requested`** signal carrying the action data; the player
+   connects it to `client_send_action_to_server`, so the tool stays decoupled from the socket.
+2. The server receives it in `server_action_received` and applies the effect (the drill
+   fractures the aimed rock).
+3. The equipped tool and its visible state are **replicated as player properties** (the drill
+   uses a `tools` property + the camera `head` pitch) so other clients see you holding and using
+   it. Remote clients apply it through the tool's **`apply_remote(data)`**, and the server sets
+   the equipped tool via **`server_set_tool(...)`**.
+
+:::warning[Whitelist the replicated properties]
+Any property you replicate for the tool (`tools`, `head`, …) must be declared in
+`player_def.json`, or it is dropped silently. See
+[Replication definition files](./props_player.md#replication-definition-files).
+:::
+
+## 4. Stowing
+
+If the tool must disappear in some states (the drill stows while the player carries an ore),
+expose a **`set_stowed(value)`** and call it from the player when that state changes.
+
+## Recommendation
+
+Because `MiningTool` is the only tool today, equip/stow, the `EquipmentMount` wiring and the
+`sync_requested` plumbing all live in one script. When a second tool arrives, factor those
+shared parts into a small **`Tool` base class** so a new tool only implements its own action —
+the same way [`GenericProp`](./props_player.md) factors carriable props.

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -1,0 +1,130 @@
+---
+title: Adding a vehicle
+sidebar_position: 3
+---
+
+# Adding a vehicle
+
+This guide walks through creating a new drivable vehicle (truck, car, rover…). Vehicles are
+server-authoritative networked props: the game server simulates the physics and replicates the
+state to every client, exactly like the other props (see
+[Props and player network management](./props_player.md)). A vehicle adds two things on top:
+**driving** (a powertrain) and **seats** (driver / passengers).
+
+All the moving parts already exist as reusable pieces — in most cases a new vehicle is just a
+**scene** to assemble, not new code.
+
+## The pieces
+
+| Script | Role |
+|---|---|
+| `scenes/vehicles/vehicle.gd` (`class_name Vehicle`) | The vehicle base: body/wheels, physics, driving, networking, cargo. Put it on the scene root. |
+| `scenes/vehicles/vehicle_powertrain.gd` | Engine math (electric / thermal gearbox). Owned by `Vehicle`, configured through its `@export`s — you don't touch it. |
+| `scenes/vehicles/vehicle_seat.gd` (`class_name VehicleSeat`) | One seat zone (driver or passenger). You drop one per seat. |
+| `scenes/vehicles/vehicle_debug_hud.gd` | Optional on-screen dashboard (speed, RPM, load). |
+
+## 1. Where to put the files
+
+- **Scene**: `scenes/vehicles/<category>/<name>.tscn` (e.g. `scenes/vehicles/trucks/truck.tscn`).
+- **Assets** (3D model, materials, textures): follow the project conventions in
+  [Files structure](../creativeConcept/files_structure.md) and
+  [3D models](../creativeConcept/3d_models.md). Do **not** invent a new layout.
+
+## 2. Build the scene
+
+Create a scene whose **root is a `VehicleBody3D`** and attach `vehicle.gd` to it.
+
+You have two options for the body:
+
+- **Real 3D model** — add your `MeshInstance3D` model and a `CollisionShape3D` matching it, as
+  children of the root.
+- **Parametric blockout (placeholder)** — `vehicle.gd` can generate a box-built body, chassis
+  collision, four wheels, cameras and the cargo bay from its exported dimensions (`@tool`, so it
+  rebuilds live in the editor). This is what the truck uses while waiting for the real model.
+  Tune it via the **Body / Cab / Bed / Wheels** export groups, and carve the cab opening with
+  **Cab → Cab Cutout Size / Offset**.
+
+The generated nodes are transient (no owner), so the `.tscn` stays minimal — only the root, its
+script and your designer-placed nodes (the seats below) are saved.
+
+## 3. Add the seats
+
+For each place, add a **`VehicleSeat`** node (an `Area3D` with `vehicle_seat.gd`) as a child of
+the root, then give it two children:
+
+```
+Truck (VehicleBody3D, vehicle.gd)
+├── SeatDriver      (Area3D, vehicle_seat.gd)   role = Driver
+│   ├── CollisionShape3D (BoxShape3D)   ← the "press E here" box, beside the door
+│   └── SitPoint (Marker3D)             ← where the occupant sits (driver: the camera eye)
+└── SeatPassenger   (Area3D, vehicle_seat.gd)   role = Passenger
+    ├── CollisionShape3D (BoxShape3D)
+    └── SitPoint (Marker3D)
+```
+
+- **`role`** (inspector): `Driver` controls the vehicle (drive input + HUD); `Passenger` just
+  rides along. Set this per seat.
+- **The box** (`CollisionShape3D`): size and place it where a player on foot stands to board
+  (e.g. left of the cab for the driver). It is the zone that enables **E**.
+- **`SitPoint`** (`Marker3D`): where the occupant is seated. For the driver it is also the
+  **camera eye**, so place it at head height inside the cab, facing forward (the vehicle's local
+  `-Z`).
+
+You don't wire anything: the `Vehicle` discovers its seats automatically, and each seat
+auto-detects the player (its collision mask is set in code). Standing in a box shows
+`[E] Drive Seat` / `[E] Passenger Seat` at the crosshair; the driver gets free mouse look while
+driving and exits with **Y**.
+
+:::tip[Seats are server-authoritative]
+A seat refuses a second occupant. The driver/passenger logic lives in the **networked** path, so
+test seats in the game (F5), not the standalone bench.
+:::
+
+## 4. Configure the powertrain
+
+On the root `Vehicle`, open the **Drive** export group:
+
+- **Propulsion Type**: `ELECTRIC` (single-speed, instant torque) or `THERMAL` (automatic
+  gearbox). The inspector shows only the relevant sub-group (**Electric** or **Thermal gearbox**).
+- Tune `engine_power`, `max_speed_kmh`, `reverse_max_kmh`, steering, brakes, and the wheel /
+  suspension settings.
+- **Mass** is the standard `RigidBody3D` mass; **Cargo** (`max_payload`, overload) drives the
+  load limiter.
+
+You never edit `vehicle_powertrain.gd` — the `Vehicle` copies these settings into it each frame
+(so you can tune them live while driving the bench).
+
+## 5. Register it on the network
+
+A vehicle only replicates if the network layer knows it:
+
+1. **Spawn registry** — add the scene path to `props_scene` in **both** `server/client.gd` and
+   `server/server.gd`:
+
+   ```
+   'scenes/vehicles/<category>/<name>.tscn':
+       preload('res://scenes/vehicles/<category>/<name>.tscn'),
+   ```
+
+   (These are plain string paths — if you ever **move** the scene, update them by hand; Godot's
+   UID rename does not touch string paths.)
+
+2. **Replication definition** — vehicles use the `vehicle` prop type, defined in
+   `horizonserver/ds_genericprops/props/vehicle_def.json` (whitelisting `position`, `rotation`,
+   `scenename`, `parent_id`, `pilot_uuid`, `steering`). If you reuse the `vehicle` type, there is
+   nothing to add. A brand-new type needs its own `<type>_def.json` — see
+   [Replication definition files](./props_player.md#replication-definition-files).
+
+:::warning[Rebuild Horizon after touching a def]
+A property (or a whole type) that is not whitelisted is dropped silently → the vehicle appears on
+the server but is **invisible** to clients (`Object definition not found for type: …`). Add it to
+the def and **rebuild Horizon**.
+:::
+
+## 6. Test
+
+- **Bench (F6)** — `scenes/vehicles/vehicle_bench.tscn` drives the vehicle locally (no network):
+  good for tuning the body, suspension and powertrain feel. The bench boards as driver only.
+- **In game (F5)** — the full flow: spawn the vehicle, walk into a seat box, **E** to board as
+  driver or passenger, drive, **Y** to leave. This is the only place seats and passengers are
+  faithful.


### PR DESCRIPTION
Où ranger : la scène dans scenes/vehicles/<catégorie>/ (ex. trucks/), les assets selon files_structure.md.

Monter la scène : racine VehicleBody3D + vehicle.gd ; 

Les places : poser des nœuds VehicleSeat (boîte CollisionShape3D + SitPoint Marker3D + role Driver/Passenger) — auto-découverts, détection auto du joueur.

Motorisation : régler vehicle_powertrain via les @export (EV/thermique, boîte, couple, vitesses) dans le groupe Drive.
Réseau : enregistrer le scenename dans le registre de spawn (client.gd/server.gd props_scene) + la def Horizon vehicle_def.json (whitelist) ; rappel du piège « def absente sur develop ».

Tester : banc (F6) pour la conduite, F5 pour les sièges.