### PR TITLE
Document carriables and the vehicle cargo bed / hand brake

### DIFF
--- a/docs/networkGame/props.md
+++ b/docs/networkGame/props.md
@@ -32,8 +32,8 @@ prop needs:
 - the `uuid` / `type_name` / position state,
 - server -> client replication every physics frame via `PropNet.server_tick(self)` —
   including **following the carrier** while the prop is held,
-- the `"carriable"` group and the carry contract (`interact()` / `set_carried()`, which also
-  disables the prop's collision while it is carried),
+- the `"carriable"` group and the carry contract (`interact()` / `set_carried()` — see
+  [Carriables](#carriables-carry--drop)),
 - reparenting and delete-on-exit.
 
 So a carriable prop is just:
@@ -58,6 +58,32 @@ and implement the contract itself, but it should still call `PropNet.server_tick
 its `_physics_process` so replication and carry-follow stay consistent. Example: the mining
 rock (`rock_mining.gd`) is custom because it fractures, and only a **fully-fractured ore
 piece** is carriable (it overrides `interact()` for that) — a whole rock is not carriable.
+
+## Carriables (carry / drop)
+
+Any prop in the `"carriable"` group can be picked up. The flow is **server-authoritative**: the
+client only aims, the server decides.
+
+- **Aiming** — the client casts its interact ray (areas only) and sends the `uuid` it looks at.
+  Hands free, it shows `[E] Carry` when the target's `interact()` allows it; while holding
+  something it shows `[E] Drop`.
+- **Pick up** (server) — the prop is frozen, parented to the player and marked carried
+  (`set_carried(true)`). `PropNet.server_tick` then re-sends its `position` + `parent_id` every
+  frame so it follows the carrier (and Horizon keeps its GORC global fresh).
+- **Drop** (server) — the prop is un-frozen, reparented back to the world, and
+  `set_carried(false)`.
+
+`interact(interactor) -> bool` is the gate (default: not already carried; the mining rock also
+requires a fully-fractured piece). `set_carried(bool)` now only flips the flag — a carried prop
+**keeps its collision** (it stays solid to the world and to other players); the carrier instead
+adds an `add_collision_exception_with()` so it is not blocked by what it holds (removed on drop).
+
+:::note[parent_id is replicated, and only re-applied on change]
+A carriable rides its carrier purely through `parent_id` (the player's, or a vehicle's bed — see
+[Vehicles → Cargo bed](./vehicles.md#cargo-bed)). The client reparents **only when `parent_id`
+actually changes** (it rides the fast zone-0 channel), and the server re-sends it for a few frames
+on a change so a single lost message can't strand the prop under its old parent.
+:::
 
 ## Update properties
 

--- a/docs/networkGame/props.md
+++ b/docs/networkGame/props.md
@@ -249,3 +249,32 @@ helper does both:
 ```
 NetworkOrchestrator.spawn_prop_authoritative(data)  # data must hold "uuid" and "type"
 ```
+
+## Moving or reparenting a prop on the Horizon side (GORC)
+
+Most prop work is done from the game server (Godot). But if you ever **change an object's
+position inside a Horizon plugin** (a move, a drop, a reparent, or recomputing a child's world
+position), there is one rule that is **essential** — getting it wrong silently breaks replication.
+
+:::warning[Always emit GORC zone events when an object moves]
+In a Horizon handler, update an object's position through
+**`events.update_object_position(...)`**, never `gorc_instances.update_object_position(...)`
+directly.
+
+`gorc_instances.update_object_position` moves the object but **discards the GORC zone
+entry/exit events**. So a player who comes within range of the object's *new* position is never
+subscribed to it and stops receiving its updates — the symptom is an object that "teleported"
+on the server but is stale on a client (e.g. a dropped item that stays glued to the carrier's
+hand). `events.update_object_position` recomputes the zones **and delivers** the entry/exit
+messages, so nearby clients (re)subscribe.
+
+For a **child** object (e.g. cargo riding in a vehicle bed), compute its world position as
+`parent_global + child_LOCAL` — read the child's **local** position from its zone data, not its
+already-global `position()`, otherwise you double-count the parent's position.
+:::
+
+This is the root cause of the old *"can't drop an item retrieved from a bed"* bug
+(horizonserver `Fix reparent`, `ds_genericprops/src/handlers/update.rs`). Note it is **not**
+fixable from the game server: re-sending the data more often does nothing if the client was never
+zone-subscribed — this kind of "update never reaches a client after the prop moved" is always a
+**GORC subscription** issue, so it belongs in Horizon, not in the Godot prop.

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -179,3 +179,28 @@ the generic Vehicle data each frame (speed, RPM, load, overload, powertrain, tra
 is reusable by any vehicle, and the Vehicle knows nothing about it. Name the Labels `speed`,
 `RPM`, `Load`, `Overloaded`, `Elec_THerm`, `Transmission`, `hanbreak`, `Light` (or adjust them in
 the script).
+
+## Rear-view camera & mirrors
+
+A live camera feed on an in-cab screen — a **drop-in** (`scenes/vehicles/rear_camera.tscn`),
+reusable and **client-only** (no render on the headless server). Use it for a reversing camera and
+for side / rear-view mirrors (the GDD allows "mirrors **or** relayed cameras"). Godot has no cheap
+real reflective surface, so a mirror is just a camera too.
+
+**Setup** (no code):
+
+1. Instance `rear_camera.tscn` under the vehicle.
+2. `RearCamera` **is** a Camera3D — place and frame it in the editor (gizmo / **Preview**), at the
+   back looking behind (or at a side mirror, looking back/outward). It never renders to the player's
+   view; a twin camera inside its `SubViewport` (sharing the main `world_3d`) copies its pose + fov
+   and renders the feed.
+3. Add a screen surface — a `MeshInstance3D` with a **`QuadMesh`** (clean `0..1` UVs) — in the cab
+   and set it as the `RearCamera`'s **`screen`**. The feed material is applied at runtime and is
+   **double-sided** (so a wrong-facing quad is never blank).
+4. **`mirror`**: off = a reversing camera (true view); on = a mirror (reverses left/right).
+5. **`resolution`**: match its aspect to the screen quad to avoid stretching.
+
+:::warning[Performance]
+Each `RearCamera` renders the whole world again every frame. A rear cam + two mirrors = three extra
+renders. Keep resolutions small; consider disabling the feeds when no one is driving.
+:::

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -73,11 +73,13 @@ Truck (VehicleBody3D, vehicle.gd)
 You don't wire anything: the `Vehicle` discovers its seats automatically, and each seat
 auto-detects the player (its collision mask is set in code). Standing in a box shows
 `[E] Drive Seat` / `[E] Passenger Seat` at the crosshair; the driver gets free mouse look while
-driving and exits with **Y**.
+driving and exits with **Y**. A taken driver seat shows `Driver seat taken` instead, the prompt is
+hidden while you are seated, and on exit you are dropped beside the seat you used.
 
 :::tip[Seats are server-authoritative]
-A seat refuses a second occupant. The driver/passenger logic lives in the **networked** path, so
-test seats in the game (F5), not the standalone bench.
+A seat refuses a second occupant, and if a seated player disconnects the server frees their seat
+automatically. The driver/passenger logic lives in the **networked** path, so test seats in the
+game (F5), not the standalone bench.
 :::
 
 ## 4. Configure the powertrain
@@ -111,8 +113,9 @@ A vehicle only replicates if the network layer knows it:
 
 2. **Replication definition** — vehicles use the `vehicle` prop type, defined in
    `horizonserver/ds_genericprops/props/vehicle_def.json` (whitelisting `position`, `rotation`,
-   `scenename`, `parent_id`, `pilot_uuid`, `steering`). If you reuse the `vehicle` type, there is
-   nothing to add. A brand-new type needs its own `<type>_def.json` — see
+   `scenename`, `parent_id`, `pilot_uuid`, `steering`, `speed`, `cargo_mass`, `handbrake`,
+   `mass`). If you reuse the `vehicle` type, there is nothing to add. A brand-new type needs its
+   own `<type>_def.json` — see
    [Replication definition files](./props.md#replication-definition-files).
 
 :::warning[Rebuild Horizon after touching a def]
@@ -129,6 +132,35 @@ the def and **rebuild Horizon**.
   driver or passenger, drive, **Y** to leave. This is the only place seats and passengers are
   faithful.
 
+## Cargo bed
+
+The blockout body generates a **cargo bay** zone (tune it via the **Cargo** export group:
+`cargo_bay_size`, `cargo_bay_offset`, `max_payload`, `overload_immobilize`). Any loose prop (a
+crate, a mined rock…) that comes to rest inside the bay is **loaded**: the server freezes it,
+parents it to the vehicle so it rides along, and folds its mass into the load. The bay detects
+cargo through its mask only and is kept off every collision layer, so it never blocks the player's
+interact ray.
+
+- **Load** = bed cargo **+ seated players**. Over `max_payload` the HUD shows `OVERLOADED`; past
+  `max_payload × overload_immobilize` the vehicle won't move.
+- **Retrieve**: aim at a loaded item and press **E** (`[E] Carry`) — it is removed from the load
+  and goes into your hands, like any [carriable](./props.md#carriables-carry--drop).
+- Another **vehicle** is never loaded as cargo (so you can't swallow a truck with a truck).
+
+:::warning[Dropping a bed-sourced item — known issue]
+An item **just retrieved from a bed** can stay visually in the carrier's hands on the client after
+it is dropped (the server drops it correctly — it is authoritative). This is a Horizon/GORC
+replication quirk on the *bed → retrieve → drop* cycle, to fix server-side. Work around it by
+re-aiming/re-taking the item or moving away.
+:::
+
+## Hand brake
+
+The driver toggles a parking **hand brake** with a **long press of Space under 3 km/h** (released
+by throttle). It holds the vehicle still on flat ground and slopes, stays dynamic so a real impact
+can still push it, and **stays engaged after the driver leaves**. It shows on the HUD and on the
+dashboard (the `hanbreak` label below).
+
 ## Dashboard — optional in-cab screen
 
 Show live data (speed, RPM, load…) on a screen in the cab using the generic 3D-screen pattern —
@@ -139,4 +171,5 @@ The **vehicle-specific** part is only the UI script: put `vehicle_dashboard.gd`
 (`VehicleDashboard`) on your UI scene's root. It finds its owning `Vehicle` in the tree and shows
 the generic Vehicle data each frame (speed, RPM, load, overload, powertrain, transmission) — so it
 is reusable by any vehicle, and the Vehicle knows nothing about it. Name the Labels `speed`,
-`RPM`, `Load`, `Overloaded`, `Elec_THerm`, `Transmission` (or adjust them in the script).
+`RPM`, `Load`, `Overloaded`, `Elec_THerm`, `Transmission`, `hanbreak` (or adjust them in the
+script).

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -114,7 +114,7 @@ A vehicle only replicates if the network layer knows it:
 2. **Replication definition** — vehicles use the `vehicle` prop type, defined in
    `horizonserver/ds_genericprops/props/vehicle_def.json` (whitelisting `position`, `rotation`,
    `scenename`, `parent_id`, `pilot_uuid`, `steering`, `speed`, `cargo_mass`, `handbrake`,
-   `mass`). If you reuse the `vehicle` type, there is nothing to add. A brand-new type needs its
+   `mass`, `headlights`). If you reuse the `vehicle` type, there is nothing to add. A brand-new type needs its
    own `<type>_def.json` — see
    [Replication definition files](./props.md#replication-definition-files).
 
@@ -146,13 +146,26 @@ interact ray.
 - **Retrieve**: aim at a loaded item and press **E** (`[E] Carry`) — it is removed from the load
   and goes into your hands, like any [carriable](./props.md#carriables-carry--drop).
 - Another **vehicle** is never loaded as cargo (so you can't swallow a truck with a truck).
+- **Rollover**: if the vehicle tips past `cargo_unlock_tilt_deg` (default 65°), the bed unlocks and
+  spills its whole load (GDD: the lock releases on a certain inclination).
 
 ## Hand brake
 
 The driver toggles a parking **hand brake** with a **long press of Space under 3 km/h** (released
-by throttle). It holds the vehicle still on flat ground and slopes, stays dynamic so a real impact
-can still push it, and **stays engaged after the driver leaves**. It shows on the HUD and on the
+by throttle). It holds the vehicle still on flat ground and slopes — once stopped it is **frozen**
+so it can't creep — and **stays engaged after the driver leaves**. Shown on the HUD and on the
 dashboard (the `hanbreak` label below).
+
+## Head lights
+
+Head lights are a **drop-in** like seats: add any **`Light3D`** (e.g. a `SpotLight3D` at the front
+facing the vehicle's local `-Z`) to the group **`vehicle_light`** anywhere under the scene — no
+code. The driver toggles them with **L**; the state is server-authoritative and replicated, so
+every client (and other players) sees them. Shown on the HUD (`[L] lights`) and on the dashboard
+(the `Light` label). The truck ships with two front SpotLights as the example.
+
+`L` is **contextual**: it drives the **head lights** while seated as driver, and the player's
+**flashlight** on foot — the two never fire at once.
 
 ## Dashboard — optional in-cab screen
 
@@ -164,5 +177,5 @@ The **vehicle-specific** part is only the UI script: put `vehicle_dashboard.gd`
 (`VehicleDashboard`) on your UI scene's root. It finds its owning `Vehicle` in the tree and shows
 the generic Vehicle data each frame (speed, RPM, load, overload, powertrain, transmission) — so it
 is reusable by any vehicle, and the Vehicle knows nothing about it. Name the Labels `speed`,
-`RPM`, `Load`, `Overloaded`, `Elec_THerm`, `Transmission`, `hanbreak` (or adjust them in the
-script).
+`RPM`, `Load`, `Overloaded`, `Elec_THerm`, `Transmission`, `hanbreak`, `Light` (or adjust them in
+the script).

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -147,13 +147,6 @@ interact ray.
   and goes into your hands, like any [carriable](./props.md#carriables-carry--drop).
 - Another **vehicle** is never loaded as cargo (so you can't swallow a truck with a truck).
 
-:::warning[Dropping a bed-sourced item — known issue]
-An item **just retrieved from a bed** can stay visually in the carrier's hands on the client after
-it is dropped (the server drops it correctly — it is authoritative). This is a Horizon/GORC
-replication quirk on the *bed → retrieve → drop* cycle, to fix server-side. Work around it by
-re-aiming/re-taking the item or moving away.
-:::
-
 ## Hand brake
 
 The driver toggles a parking **hand brake** with a **long press of Space under 3 km/h** (released


### PR DESCRIPTION
Documents the carry system and the vehicle cargo bed / hand brake, and fixes a stale note.

- props.md: new "Carriables (carry / drop)" section (server-authoritative aim → pick up/drop,
  interact()/set_carried() contract, carried props keep collision via a carrier exception,
  parent_id replicated and only re-applied on change). Fixes the outdated claim that
  set_carried() disables collision.
- vehicles.md: new "Cargo bed" section (load = cargo + passengers, OVERLOADED, retrieve with E,
  no vehicle-in-bed) with a warning about the known bed-sourced-drop replication quirk; new
  "Hand brake" section; seat-freed-on-disconnect + "Driver seat taken" + exit-beside-the-seat;
  updated vehicle_def.json whitelist and dashboard label list.
-Documents the carriables (carry/drop), the vehicle cargo bed (load/retrieve/rollover spill),
hand brake, head lights, and the Horizon GORC position-update rule (events.update_object_position).
Also fixes a stale note (set_carried no longer disables collision).
