### PR TITLE
Document server-authoritative interaction (carry: line of sight + ser…

### DIFF
--- a/docs/networkGame/player.md
+++ b/docs/networkGame/player.md
@@ -87,7 +87,9 @@ The carry/pickup illustrates the pattern:
   raycasts from the player's eye to the prop and refuses if any solid body (a wall/building)
   is in between, so a thin wall can't be exploited to grab through it. The prop itself and its
   holder (a vehicle bed, a depot, the ground it rests on) are ignored, so taking a crate out
-  of a bed still works.
+  of a bed still works. Very small or fragmented props (e.g. a mining rock) are **exempt** from
+  the line-of-sight check: their thin, broken-up colliders made the ray report a false block, so
+  the server skips the wall test for them and relies on reach alone.
 - **The prompt is server-driven.** The server computes `[E] Carry` / `[E] Drop` (reachable, in
   line of sight, not already carried by someone else) and replicates it to the owning client,
   which only displays it — the client never decides the prompt itself.

--- a/docs/networkGame/player.md
+++ b/docs/networkGame/player.md
@@ -73,3 +73,23 @@ func client_channel_data_update(data: Dictionary) -> void:
 if data.has("health"):
 health = data["health"]
 ```
+
+## Server-authoritative interaction (carry example)
+
+Interaction must be decided by the **server**, never trusted from the client — this is an MMO,
+so the server is the anti-cheat authority. The client may show prompts and predictions for
+instant feedback, but the server re-checks everything before acting.
+
+The carry/pickup illustrates the pattern:
+
+- **Reachability + line of sight** are checked **on the server** (it owns the collisions; the
+  client often has none — e.g. server-only terrain). Before granting a pickup the server
+  raycasts from the player's eye to the prop and refuses if any solid body (a wall/building)
+  is in between, so a thin wall can't be exploited to grab through it. The prop itself and its
+  holder (a vehicle bed, a depot, the ground it rests on) are ignored, so taking a crate out
+  of a bed still works.
+- **The prompt is server-driven.** The server computes `[E] Carry` / `[E] Drop` (reachable, in
+  line of sight, not already carried by someone else) and replicates it to the owning client,
+  which only displays it — the client never decides the prompt itself.
+- Because that prompt is a replicated player property, it must be whitelisted in
+  `player_def.json` (see the warning above) or Horizon drops it.


### PR DESCRIPTION
## Description
Add a "Server-authoritative interaction" section to `networkGame/player.md`, using the carry as the example: server-side line of sight, server-driven prompt, and the `player_def.json` whitelist reminder.
