### PR TITLE
Vehicle docs: player-monitored seats, bed cargo, hand brake, lights, rear camera (+ rock mass)

### DIFF
--- a/docs/networkGame/props.md
+++ b/docs/networkGame/props.md
@@ -30,8 +30,10 @@ prop needs:
 
 - the replication signals (`hs_server_prop_update` / `hs_server_prop_delete`),
 - the `uuid` / `type_name` / position state,
-- server -> client replication every physics frame via `PropNet.server_tick(self)` —
-  including **following the carrier** while the prop is held,
+- server -> client replication driven by `PropNet.server_tick(self)`, which sends an update
+  **only when** the prop's local position/rotation/parent actually changes (not every frame); a
+  held or loaded prop does **not** re-announce itself — Horizon rebuilds its world position from
+  its parent (see [Carriables](#carriables-carry--drop)),
 - the `"carriable"` group and the carry contract (`interact()` / `set_carried()` — see
   [Carriables](#carriables-carry--drop)),
 - reparenting and delete-on-exit.
@@ -76,8 +78,9 @@ client only aims, the server decides.
   Hands free, it shows `[E] Carry` when the target's `interact()` allows it; while holding
   something it shows `[E] Drop`.
 - **Pick up** (server) — the prop is frozen, parented to the player and marked carried
-  (`set_carried(true)`). `PropNet.server_tick` then re-sends its `position` + `parent_id` every
-  frame so it follows the carrier (and Horizon keeps its GORC global fresh).
+  (`set_carried(true)`). Its `parent_id` becomes the player, so Horizon keeps its GORC global
+  fresh by recomputing it from the carrier — the prop follows **without** re-sending its
+  transform every frame (`PropNet.server_tick` emits only on a real change).
 - **Drop** (server) — the prop is un-frozen, reparented back to the world, and `set_carried(false)`.
   Dropped **while standing in a vehicle bed**, it is loaded onto that vehicle instead (see
   [Vehicles → Cargo bed](./vehicles.md#cargo--loading-the-bed)).
@@ -90,8 +93,9 @@ prop also ignores every **vehicle** so it can't shove a much heavier truck.
 
 :::note[parent_id is replicated, and only re-applied on change]
 A carriable rides its carrier purely through `parent_id` (the player's, or a vehicle's bed). The
-client reparents **only when `parent_id` actually changes**, and the server re-sends it for a few
-frames on a change so a single lost message can't strand the prop under its old parent.
+server replicates `parent_id` **only when it actually changes**, and the client reparents only
+then. Delivering that single message reliably is Horizon's job — the prop does not re-send it
+"just in case".
 :::
 
 ## Update properties

--- a/docs/networkGame/props.md
+++ b/docs/networkGame/props.md
@@ -32,8 +32,8 @@ prop needs:
 - the `uuid` / `type_name` / position state,
 - server -> client replication every physics frame via `PropNet.server_tick(self)` —
   including **following the carrier** while the prop is held,
-- the `"carriable"` group and the carry contract (`interact()` / `set_carried()`, which also
-  disables the prop's collision while it is carried),
+- the `"carriable"` group and the carry contract (`interact()` / `set_carried()` — see
+  [Carriables](#carriables-carry--drop)),
 - reparenting and delete-on-exit.
 
 So a carriable prop is just:
@@ -66,6 +66,33 @@ and implement the contract itself, but it should still call `PropNet.server_tick
 its `_physics_process` so replication and carry-follow stay consistent. Example: the mining
 rock (`rock_mining.gd`) is custom because it fractures, and only a **fully-fractured ore
 piece** is carriable (it overrides `interact()` for that) — a whole rock is not carriable.
+
+## Carriables (carry / drop)
+
+Any prop in the `"carriable"` group can be picked up. The flow is **server-authoritative**: the
+client only aims, the server decides.
+
+- **Aiming** — the client casts its interact ray (areas only) and sends the `uuid` it looks at.
+  Hands free, it shows `[E] Carry` when the target's `interact()` allows it; while holding
+  something it shows `[E] Drop`.
+- **Pick up** (server) — the prop is frozen, parented to the player and marked carried
+  (`set_carried(true)`). `PropNet.server_tick` then re-sends its `position` + `parent_id` every
+  frame so it follows the carrier (and Horizon keeps its GORC global fresh).
+- **Drop** (server) — the prop is un-frozen, reparented back to the world, and `set_carried(false)`.
+  Dropped **while standing in a vehicle bed**, it is loaded onto that vehicle instead (see
+  [Vehicles → Cargo bed](./vehicles.md#cargo--loading-the-bed)).
+
+`interact(interactor) -> bool` is the gate (default: not already carried; the mining rock also
+requires a fully-fractured piece). `set_carried(bool)` only flips the flag — a carried prop **keeps
+its collision** (it stays solid to the world and to other players); the carrier instead adds an
+`add_collision_exception_with()` so it is not blocked by what it holds (removed on drop), and a held
+prop also ignores every **vehicle** so it can't shove a much heavier truck.
+
+:::note[parent_id is replicated, and only re-applied on change]
+A carriable rides its carrier purely through `parent_id` (the player's, or a vehicle's bed). The
+client reparents **only when `parent_id` actually changes**, and the server re-sends it for a few
+frames on a change so a single lost message can't strand the prop under its old parent.
+:::
 
 ## Update properties
 
@@ -231,3 +258,30 @@ helper does both:
 ```
 NetworkOrchestrator.spawn_prop_authoritative(data)  # data must hold "uuid" and "type"
 ```
+
+## Moving or reparenting a prop on the Horizon side (GORC)
+
+Most prop work is done from the game server (Godot). But if you ever **change an object's position
+inside a Horizon plugin** (a move, a drop, a reparent, or recomputing a child's world position),
+there is one rule that is **essential** — getting it wrong silently breaks replication.
+
+:::warning[Always emit GORC zone events when an object moves]
+In a Horizon handler, update an object's position through **`events.update_object_position(...)`**,
+never `gorc_instances.update_object_position(...)` directly.
+
+`gorc_instances.update_object_position` moves the object but **discards the GORC zone entry/exit
+events**. So a player who comes within range of the object's *new* position is never subscribed to
+it and stops receiving its updates — the symptom is an object that "teleported" on the server but
+is stale on a client (e.g. a dropped item glued to the carrier's hand). `events.update_object_position`
+recomputes the zones **and delivers** the entry/exit messages, so nearby clients (re)subscribe.
+
+For a **child** object (e.g. cargo riding in a vehicle bed), compute its world position as
+`parent_global + child_LOCAL` — read the child's **local** position from its zone data, not its
+already-global `position()`, otherwise you double-count the parent's position.
+:::
+
+This is the root cause of the old *"can't drop an item retrieved from a bed"* bug (horizonserver
+`Fix reparent`, `ds_genericprops/src/handlers/update.rs`). It is **not** fixable from the game
+server: re-sending the data more often does nothing if the client was never zone-subscribed — this
+kind of "update never reaches a client after the prop moved" is always a **GORC subscription**
+issue, so it belongs in Horizon, not in the Godot prop.

--- a/docs/networkGame/props.md
+++ b/docs/networkGame/props.md
@@ -51,6 +51,14 @@ Build the scene (a body + collision shape + mesh), attach the script, and declar
 `<type>_def.json` (see [Replication definition files](#replication-definition-files)). Done —
 no boilerplate to copy.
 
+:::note[Set the prop's mass]
+Set the `RigidBody3D` **Mass** on your prop's scene (Inspector). It is the prop's weight
+everywhere in the game — its physics behaviour, and what a vehicle bed counts as cargo load
+(see [Cargo — loading the bed](./vehicles.md)). A prop left at the default **1 kg** feels
+weightless and barely registers as cargo, so give it a realistic value. (The mining rock sets
+this per-piece from its volume instead of a fixed value.)
+:::
+
 ### Complex props
 
 A prop with special behaviour may stay a standalone script (extending whatever body it needs)

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -74,12 +74,14 @@ You don't wire anything: the `Vehicle` discovers its seats automatically. The se
 **passive** — it never monitors. Instead the **player's own detector** is the single monitor that
 reports when it walks into a seat zone. This avoids every seat of every vehicle running a
 broad-phase overlap test each physics frame, and it works identically on client and server.
-Standing in a box shows `[E] Drive Seat` / `[E] Passenger Seat` at the crosshair; the driver gets
-free mouse look while driving and exits with **Y**.
+Standing in a box shows `[E] Drive Seat` / `[E] Passenger Seat` at the crosshair; a taken driver
+seat shows `Driver seat taken` instead. The driver gets free mouse look while driving and exits
+with **Y**; the prompt is hidden while seated, and on exit you are dropped beside the seat you used.
 
 :::tip[Seats are server-authoritative]
-A seat refuses a second occupant. The driver/passenger logic lives in the **networked** path, so
-test seats in the game (F5), not the standalone bench.
+A seat refuses a second occupant, and if a seated player disconnects the server frees their seat
+automatically. The driver/passenger logic lives in the **networked** path, so test seats in the
+game (F5), not the standalone bench.
 :::
 
 ## 4. Configure the powertrain
@@ -113,8 +115,9 @@ A vehicle only replicates if the network layer knows it:
 
 2. **Replication definition** — vehicles use the `vehicle` prop type, defined in
    `horizonserver/ds_genericprops/props/vehicle_def.json` (whitelisting `position`, `rotation`,
-   `scenename`, `parent_id`, `pilot_uuid`, `steering`). If you reuse the `vehicle` type, there is
-   nothing to add. A brand-new type needs its own `<type>_def.json` — see
+   `scenename`, `parent_id`, `pilot_uuid`, `steering`, `speed`, `cargo_mass`, `handbrake`, `mass`,
+   `headlights`). If you reuse the `vehicle` type, there is nothing to add. A brand-new type needs
+   its own `<type>_def.json` — see
    [Replication definition files](./props.md#replication-definition-files).
 
 :::warning[Rebuild Horizon after touching a def]
@@ -133,15 +136,19 @@ the def and **rebuild Horizon**.
 
 ## Cargo — loading the bed
 
-A vehicle with a bed carries cargo, and the load counts toward `max_payload` (the overload limiter
-shown on the dashboard).
+The blockout body generates a **cargo bay** zone (tune it via the **Cargo** export group:
+`cargo_bay_size`, `cargo_bay_offset`, `max_payload`, `overload_immobilize`). The load counts toward
+`max_payload`, the overload limiter shown on the dashboard.
 
-- **Loading** — carry a prop (a crate, a mining rock) and **drop it while standing in the bed**.
-  The carrier hands it to the truck: the prop is frozen, parented to the vehicle and rides with it.
-  Like the seats, the bed is a **passive zone** — it does not poll every frame; the carrier, who
-  knows it is standing in the bed, loads the prop on drop. Retrieve it with **E**.
+- **Loading** — carry a prop (a crate, a mined rock) and **drop it while standing in the bed**. The
+  carrier hands it to the truck: the prop is frozen, parented to the vehicle so it rides along, and
+  its mass is folded into the load. Like the seats, the bed is a **passive zone** — it never polls;
+  the carrier, who knows it is standing in the bed, loads the prop on drop (so the bay never blocks
+  the interact ray either).
 - **A held prop passes through vehicles** while carried, so a held box can't shove or flip a much
   heavier truck — you load by dropping, not by ramming.
+- **Retrieve** — aim at a loaded item and press **E** (`[E] Carry`); it leaves the load and goes
+  into your hands, like any [carriable](./props.md#carriables-carry--drop).
 - **What counts as load**:
   - the props locked in the bed — each prop's weight is its `RigidBody` **mass**;
   - **on-foot players** standing in the bed (their body mass), **plus whatever they hold** in their
@@ -149,11 +156,34 @@ shown on the dashboard).
 - **A mining rock's mass scales with its size**: a whole rock keeps the mass set on its scene
   `RigidBody` (the GameDesigner value); a cut piece weighs that scaled by its volume ratio (a half
   ≈ half, a quarter ≈ a quarter), so smaller pieces load the bed less.
+- Over `max_payload` the HUD shows `OVERLOADED`; past `max_payload × overload_immobilize` the
+  vehicle won't move. Another **vehicle** is never loaded as cargo (no swallowing a truck with a
+  truck).
+- **Rollover** — if the vehicle tips past `cargo_unlock_tilt_deg` (default 65°), the bed unlocks and
+  spills its whole load (GDD: the lock releases past a certain inclination).
 
 :::note[Riding a moving bed]
 Standing in the bed adds the weight, but **walking** in a *moving* bed (riding it on foot) is not
 supported yet — it needs client-side prediction. A moving truck currently leaves a walker behind.
 :::
+
+## Hand brake
+
+The driver toggles a parking **hand brake** with a **long press of Space under 3 km/h** (released by
+throttle). It holds the vehicle still on flat ground and slopes — once stopped it is **frozen** so
+it can't creep — and **stays engaged after the driver leaves**. Shown on the HUD and on the
+dashboard.
+
+## Head lights
+
+Head lights are a **drop-in** like seats: add any **`Light3D`** (e.g. a `SpotLight3D` at the front
+facing the vehicle's local `-Z`) to the group **`vehicle_light`** anywhere under the scene — no
+code. The driver toggles them with **L**; the state is server-authoritative and replicated, so every
+client sees them. Shown on the HUD (`[L] lights`) and on the dashboard. The truck ships with two
+front SpotLights as the example.
+
+`L` is **contextual**: it drives the **head lights** while seated as driver, and the player's
+**flashlight** on foot — the two never fire at once.
 
 ## Dashboard — optional in-cab screen
 
@@ -165,4 +195,30 @@ The **vehicle-specific** part is only the UI script: put `vehicle_dashboard.gd`
 (`VehicleDashboard`) on your UI scene's root. It finds its owning `Vehicle` in the tree and shows
 the generic Vehicle data each frame (speed, RPM, load, overload, powertrain, transmission) — so it
 is reusable by any vehicle, and the Vehicle knows nothing about it. Name the Labels `speed`,
-`RPM`, `Load`, `Overloaded`, `Elec_THerm`, `Transmission` (or adjust them in the script).
+`RPM`, `Load`, `Overloaded`, `Elec_THerm`, `Transmission`, `hanbreak`, `Light` (or adjust them in
+the script).
+
+## Rear-view camera & mirrors
+
+A live camera feed on an in-cab screen — a **drop-in** (`scenes/vehicles/rear_camera.tscn`),
+reusable and **client-only** (no render on the headless server). Use it for a reversing camera and
+for side / rear-view mirrors (the GDD allows "mirrors **or** relayed cameras"). Godot has no cheap
+real reflective surface, so a mirror is just a camera too.
+
+**Setup** (no code):
+
+1. Instance `rear_camera.tscn` under the vehicle.
+2. `RearCamera` **is** a Camera3D — place and frame it in the editor (gizmo / **Preview**), at the
+   back looking behind (or at a side mirror, looking back/outward). It never renders to the player's
+   view; a twin camera inside its `SubViewport` (sharing the main `world_3d`) copies its pose + fov
+   and renders the feed.
+3. Add a screen surface — a `MeshInstance3D` with a **`QuadMesh`** (clean `0..1` UVs) — in the cab
+   and set it as the `RearCamera`'s **`screen`**. The feed material is applied at runtime and is
+   **double-sided** (so a wrong-facing quad is never blank).
+4. **`mirror`**: off = a reversing camera (true view); on = a mirror (reverses left/right).
+5. **`resolution`**: match its aspect to the screen quad to avoid stretching.
+
+:::warning[Performance]
+Each `RearCamera` renders the whole world again every frame. A rear cam + two mirrors = three extra
+renders. Keep resolutions small; consider disabling the feeds when no one is driving.
+:::

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -136,15 +136,27 @@ the def and **rebuild Horizon**.
 
 ## Cargo — loading the bed
 
-The blockout body generates a **cargo bay** zone (tune it via the **Cargo** export group:
-`cargo_bay_size`, `cargo_bay_offset`, `max_payload`, `overload_immobilize`). The load counts toward
-`max_payload`, the overload limiter shown on the dashboard.
+Two **designer-placed** zones drive cargo (no per-vehicle code):
 
-- **Loading** — carry a prop (a crate, a mined rock) and **drop it while standing in the bed**. The
-  carrier hands it to the truck: the prop is frozen, parented to the vehicle so it rides along, and
-  its mass is folded into the load. Like the seats, the bed is a **passive zone** — it never polls;
-  the carrier, who knows it is standing in the bed, loads the prop on drop (so the bay never blocks
-  the interact ray either).
+- **`cargo_bay`** — where cargo *sits*. Tune it via the **Cargo** export group (`cargo_bay_size`,
+  `cargo_bay_offset`, `max_payload`, `overload_immobilize`). It is also the passive zone the player's
+  detector overlaps to count their weight while standing in the bed.
+- **`Cargo_loading_zone`** — where dropping is *allowed to load* (it sticks). Add a `CollisionShape3D`
+  with a `BoxShape3D` named `Cargo_loading_zone` (or assign it to the `Vehicle`'s **Cargo loading
+  zone** export), sized a bit larger than the bay so reaching over the wall counts. Its physics
+  collision is turned off at runtime — it is only a zone marker. If unset, the `cargo_bay` box is
+  used as a fallback.
+
+The load counts toward `max_payload`, the overload limiter shown on the dashboard.
+
+- **Loading** — carry a prop (a crate, a mined rock) and **drop it inside the loading zone** —
+  whether you stand in the bed *or* reach over from outside; the zone (not your position) decides. The
+  `[E]` prompt reads **`[E] Cargo`** when dropping would load it (it sticks) and **`[E] Drop`**
+  otherwise. The carrier hands it to the truck: the prop is frozen, parented to the vehicle so it
+  rides along, and its mass is folded into the load. The bed never polls — loading happens on drop.
+- **Placed in the bay** — a loaded item is tucked **entirely inside** the `cargo_bay` (using its real
+  collision bounds, so any size or off-centre pivot fits) and rested on the bed floor, even when
+  dropped from far / over the rim.
 - **A held prop passes through vehicles** while carried, so a held box can't shove or flip a much
   heavier truck — you load by dropping, not by ramming.
 - **Retrieve** — aim at a loaded item and press **E** (`[E] Carry`); it leaves the load and goes
@@ -165,6 +177,41 @@ The blockout body generates a **cargo bay** zone (tune it via the **Cargo** expo
 :::note[Riding a moving bed]
 Standing in the bed adds the weight, but **walking** in a *moving* bed (riding it on foot) is not
 supported yet — it needs client-side prediction. A moving truck currently leaves a walker behind.
+:::
+
+### How the load rides the truck (freeze mode)
+
+A loaded crate must follow the truck **rigidly** — and it is a `RigidBody3D`, which the physics engine
+places in **global** space, *not* by inheriting its parent's transform. So parenting a crate under the
+truck is **not enough**; how it is frozen matters.
+
+:::warning[Use FREEZE_MODE_KINEMATIC for a body riding a moving parent — never STATIC]
+A frozen `RigidBody3D` has two modes:
+
+- **`FREEZE_MODE_STATIC`** (the default for a frozen body) behaves like a `StaticBody`: the physics
+  server keeps **rewriting its world transform every physics frame**. Under a moving parent it stays
+  put in the world while the truck drives off — the *"cargo left behind at speed"* bug.
+- **`FREEZE_MODE_KINEMATIC`** is *animatable*: the body **follows its node's transform**
+  (`parent_global × local`), so as the truck moves, the crate rides with it.
+
+The crate is set **KINEMATIC** on both sides: the server does it when it locks the crate, and each
+client does it for the replica **derived from the parent** — when a prop is reparented under a
+`Vehicle` it switches to KINEMATIC, and back to STATIC when it returns to the world (`PropNet.apply_ride_freeze_mode`). Nothing extra is replicated for this: the client reads it from `parent_id`, which already travels.
+:::
+
+On top of that, two pins keep it perfectly stuck:
+
+- **Server pin** — each physics frame the vehicle re-asserts every locked crate's **constant local
+  pose** in the bed (`_pin_locked_cargo`), so a KINEMATIC body can't drift relative to the moving
+  truck. The replicated local position therefore stays constant.
+- **Client pin** — each render frame the prop re-asserts that same local pose
+  (`PropNet.ride_pin`), so the crate tracks the **render-interpolated** truck without stepping at the
+  physics rate (which would jitter). A direct set, not a lerp.
+
+:::note[Cargo debug envelope]
+Turn on **Settings → General → Cargo debug** to draw a green envelope around every crate that is
+*really* locked in a bed (i.e. reparented under the vehicle). An item merely resting loose in the bed
+gets none — a quick way to tell "stuck" from "just sitting there".
 :::
 
 ## Hand brake
@@ -214,11 +261,21 @@ real reflective surface, so a mirror is just a camera too.
    and renders the feed.
 3. Add a screen surface — a `MeshInstance3D` with a **`QuadMesh`** (clean `0..1` UVs) — in the cab
    and set it as the `RearCamera`'s **`screen`**. The feed material is applied at runtime and is
-   **double-sided** (so a wrong-facing quad is never blank).
+   **one-sided** (shows only on the quad's front face). If a screen is blank, the quad faces the
+   wrong way — tick **Flip Faces** on its mesh or rotate it 180°. (Flip Faces only changes which side
+   is visible; it does **not** flip the image left/right — that is the `mirror` flag below.)
 4. **`mirror`**: off = a reversing camera (true view); on = a mirror (reverses left/right).
 5. **`resolution`**: match its aspect to the screen quad to avoid stretching.
+6. **`max_distance`** / **`refresh_hz`**: see Performance below.
 
-:::warning[Performance]
-Each `RearCamera` renders the whole world again every frame. A rear cam + two mirrors = three extra
-renders. Keep resolutions small; consider disabling the feeds when no one is driving.
+:::warning[Performance — each feed is a second full render]
+Each `RearCamera` renders the whole world again, so a rear cam + two mirrors = three extra renders.
+Two built-in limiters keep this cheap on weak GPUs (the screens still stay live for everyone):
+
+- **`max_distance`** — beyond this distance from the viewer the feed stops rendering (keeps its last
+  image; it is unreadable from afar anyway). `0` disables the distance cull.
+- **`refresh_hz`** — how many times per second the feed re-renders (default 20, not the full frame
+  rate). `0` renders every frame.
+
+Also keep `resolution` small.
 :::

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -70,10 +70,12 @@ Truck (VehicleBody3D, vehicle.gd)
   **camera eye**, so place it at head height inside the cab, facing forward (the vehicle's local
   `-Z`).
 
-You don't wire anything: the `Vehicle` discovers its seats automatically, and each seat
-auto-detects the player (its collision mask is set in code). Standing in a box shows
-`[E] Drive Seat` / `[E] Passenger Seat` at the crosshair; the driver gets free mouse look while
-driving and exits with **Y**.
+You don't wire anything: the `Vehicle` discovers its seats automatically. The seat box is
+**passive** — it never monitors. Instead the **player's own detector** is the single monitor that
+reports when it walks into a seat zone. This avoids every seat of every vehicle running a
+broad-phase overlap test each physics frame, and it works identically on client and server.
+Standing in a box shows `[E] Drive Seat` / `[E] Passenger Seat` at the crosshair; the driver gets
+free mouse look while driving and exits with **Y**.
 
 :::tip[Seats are server-authoritative]
 A seat refuses a second occupant. The driver/passenger logic lives in the **networked** path, so
@@ -128,6 +130,30 @@ the def and **rebuild Horizon**.
 - **In game (F5)** — the full flow: spawn the vehicle, walk into a seat box, **E** to board as
   driver or passenger, drive, **Y** to leave. This is the only place seats and passengers are
   faithful.
+
+## Cargo — loading the bed
+
+A vehicle with a bed carries cargo, and the load counts toward `max_payload` (the overload limiter
+shown on the dashboard).
+
+- **Loading** — carry a prop (a crate, a mining rock) and **drop it while standing in the bed**.
+  The carrier hands it to the truck: the prop is frozen, parented to the vehicle and rides with it.
+  Like the seats, the bed is a **passive zone** — it does not poll every frame; the carrier, who
+  knows it is standing in the bed, loads the prop on drop. Retrieve it with **E**.
+- **A held prop passes through vehicles** while carried, so a held box can't shove or flip a much
+  heavier truck — you load by dropping, not by ramming.
+- **What counts as load**:
+  - the props locked in the bed — each prop's weight is its `RigidBody` **mass**;
+  - **on-foot players** standing in the bed (their body mass), **plus whatever they hold** in their
+    hands.
+- **A mining rock's mass scales with its size**: a whole rock keeps the mass set on its scene
+  `RigidBody` (the GameDesigner value); a cut piece weighs that scaled by its volume ratio (a half
+  ≈ half, a quarter ≈ a quarter), so smaller pieces load the bed less.
+
+:::note[Riding a moving bed]
+Standing in the bed adds the weight, but **walking** in a *moving* bed (riding it on foot) is not
+supported yet — it needs client-side prediction. A moving truck currently leaves a walker behind.
+:::
 
 ## Dashboard — optional in-cab screen
 

--- a/docs/vFX/minerals.md
+++ b/docs/vFX/minerals.md
@@ -96,6 +96,13 @@ So one texture set feeds **two** outputs — keep both in the mineral's folder:
 
 ## Notes & gotchas
 
+:::note[A rock's mass is a rock property, not a mineral one]
+The `MineralDef` is **look only**. A mining rock's **mass** (its weight as truck cargo) is a
+rock-physics property: it comes from the `RigidBody` mass set on the rock scene (the GameDesigner
+value), scaled by each cut piece's **volume** — a half weighs ~half, a quarter ~a quarter. See
+[Cargo — loading the bed](../networkGame/vehicles.md). Swapping the mineral never changes it.
+:::
+
 :::caution[A metal shows its reflection, not its texture]
 With `metallic = 1` the surface displays the **reflected environment**, not the albedo: under a
 **blue sky** it reads blue-grey, in the **dark** it reads black — it only looks gold with a


### PR DESCRIPTION
Consolidates the vehicle/cargo documentation into one coherent, **up-to-date** set, and **supersedes #39** (carry-vehicle-cargo).

`networkGame/vehicles.md`:
- **Seats** are now passive: the player's own detector is the single monitor (perf), with the taken-seat prompt, disconnect-frees-seat and drop-beside-on-exit details.
- **Cargo bed** rewritten to the current code: load by **dropping a carried prop in the bed** (not the old auto-absorb), a held prop passes through vehicles, retrieve with E, load = locked props + on-foot walkers + what they carry, rollover spill, `max_payload`/overload.
- **A mining rock's mass scales with its cut volume.**
- Kept from #39: **hand brake**, **head lights** (contextual `L`), **rear-view camera & mirrors**, the expanded replication whitelist and the dashboard labels.

`networkGame/props.md`:
- New **Carriables (carry / drop)** flow (server-authoritative aim → pick up → drop, incl. drop-into-bed loading and the held-prop-passes-through-vehicles rule).
- New **Horizon GORC update rule** (`events.update_object_position` vs `gorc_instances`, child local-position) — the root cause of the old "can't drop from a bed" bug.
- Note to **set the prop's `RigidBody` mass** (its weight everywhere + cargo).

`vFX/minerals.md`: note that a rock's mass is a rock-physics property (not the `MineralDef`).

➡️ **#39 can be closed** as superseded by this PR.

## Changelog

<!-- CHANGELOG_EN -->
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
<!-- /CHANGELOG_FR -->