### PR TITLE
Network, vehicle & controls documentation (consolidated, plain-language)

### DIFF
--- a/docs/networkGame/intro.md
+++ b/docs/networkGame/intro.md
@@ -3,4 +3,126 @@ title: Network Game Introduction
 sidebar_position: 1
 ---
 
-# Team Network Game Technical Documentation
+# How DyingStar networking works
+
+This page explains the **big picture** of multiplayer in DyingStar, in plain language, before
+you read the more technical pages ([Player](./player.md), [Props](./props.md),
+[Vehicles](./vehicles.md)). You don't need to be a network engineer to follow it — read it once
+and the rest of the section will make sense.
+
+## The one rule that explains everything
+
+> **The server decides. The client only shows.**
+
+In DyingStar, your game (the *client*) is **not** in charge of what happens. It is a window: it
+shows you the world and sends your inputs ("I press forward", "I press E") to the server. The
+**server** is the only place where the real world exists — it runs the physics, checks the
+collisions, and decides the result. Then it tells every client what to display.
+
+This is called **server-authoritative**. It is what keeps everyone's game in sync and stops
+cheating. If you ever find yourself making the client "decide" something (move itself through a
+wall, pick up an item on its own, change who it is attached to), it is almost always a bug.
+
+## The four actors
+
+Multiplayer in DyingStar is a conversation between four parts. Each one has **a single job**.
+Mixing up their jobs is the source of most networking bugs.
+
+| Actor | What it is | Its only job |
+|---|---|---|
+| **Game server** (GodotServer) | A copy of the game running with no screen ("headless"), on the server | **The authority.** Runs physics, collisions, and all gameplay decisions. The single source of truth. |
+| **Horizon** | A separate program written in Rust | The **post office**. It does *no* gameplay. It stores each object's latest state and decides **who receives which update**. |
+| **GORC** | A system *inside* Horizon | The **filter**. "This player is close enough to that rock to care about it — send it. That one is too far — don't." |
+| **Client** | The game on the player's machine | The **window**. Shows the world, sends your inputs up, and smooths out what it receives. It has **no authority**. |
+
+A useful image: the **game server** is the director of a play who knows the whole script;
+**Horizon + GORC** are the stage crew who decide which spectators can see which part of the
+stage; the **client** is one spectator watching from their seat.
+
+## Why a separate "post office" (Horizon + GORC)?
+
+An MMO can have thousands of objects. If every client received every update about every object,
+the network would melt. So Horizon only sends you what is **near you**, and not too often.
+
+That filtering is **GORC**. For each *type* of object (a box, a player, a vehicle…), a small
+configuration file says, per kind of data:
+
+- **how far** it travels (a radius in meters — past it, you simply don't get the update), and
+- **how often** it is sent (a few times per second for slow data, up to 30 times for fast data
+  like position).
+
+These files are the **replication definition files**, explained in
+[Props network management](./props.md#replication-definition-files). The important takeaway:
+**a piece of data only reaches other players if it is declared in that file.** Forget to declare
+it and it silently never arrives — a very common beginner trap.
+
+## The backbone: parents (`parent_id`)
+
+This is the most important idea in the whole system, and the one that causes the trickiest bugs.
+
+**Every object's position is stored *relative to a parent*, not in absolute world coordinates.**
+
+- A planet is a parent. A city sitting on the planet is its child. A building in the city is a
+  child of the city. A box inside a truck is a child of the truck. A crate you carry is a child
+  of *you*.
+- Each object only knows its **local** position ("I am 2 meters in front of my parent"). The
+  parent is identified by a `parent_id`.
+
+Horizon rebuilds the **real (global) position** by adding up the chain:
+`my world position = my parent's world position + my local position`.
+
+Why bother? Because the world **moves**. Planets orbit at gigantic coordinates. If a box stored
+its own absolute position, it would drift away from the planet it sits on the moment the planet
+moved. By storing the box *relative to the planet*, it rides along automatically.
+
+Two consequences worth remembering:
+
+1. **When a parent moves, Horizon automatically recomputes where all its children are.** A box
+   in a moving truck does **not** have to keep announcing its position — the truck's movement
+   already carries it. (Re-announcing it every frame is exactly the kind of mistake that floods
+   the network; see the golden rules below.)
+2. **Who your parent is, is a server decision.** When you walk into a building that becomes your
+   new parent, the *server* changes your `parent_id` and tells the clients. A client never
+   re-parents itself.
+
+## The life of one update
+
+Putting it together — here is what happens when, say, a box is pushed on the server:
+
+1. **Game server**: physics moves the box. The box notices its local position changed and sends
+   one small message: "box `1234` is now *here* (relative to my parent)".
+2. **Horizon**: receives it, computes the box's real world position from its parent, updates
+   GORC (so players who just came into range start receiving it, and those who left stop), and
+   forwards the change **only to the clients that are close enough**.
+3. **Clients in range**: receive "box `1234` moved" and smoothly update the box on screen. Clients
+   too far away never hear about it.
+
+The player works the **same way** — a player is just an object of type `player`. The only extra
+part is that *your* client also sends your inputs/actions *up* to the server (see
+[Player network management](./player.md)).
+
+## The golden rules
+
+These six rules prevent the great majority of networking bugs. Every later page is an
+application of them.
+
+1. **The server decides, the client shows.** Always — including movement, pickups, and parenting,
+   for your own player too.
+2. **Send a change only when it actually changes**, and send only the field that changed — never
+   the whole state every frame. Re-sending unchanged data floods the network and freezes the
+   game.
+3. **Positions are local to a parent.** Let Horizon rebuild the world position. A child of a
+   moving thing does not re-announce itself.
+4. **A piece of data only travels if it is declared** in the object type's replication
+   definition file.
+5. **After re-parenting a node, reset its interpolation** so it doesn't visually slide from its
+   old spot (a Godot detail explained in the player/props pages).
+6. **Deleting a parent? Re-attach its children first**, otherwise they are left pointing at
+   something that no longer exists and turn into "ghosts" on other clients.
+
+## Where to go next
+
+- [Player network management](./player.md) — sending your inputs up, receiving results down.
+- [Props network management](./props.md) — how any object (box, rock, building…) replicates,
+  the definition files, and deletion.
+- [Adding a vehicle](./vehicles.md) — a worked example that combines all of the above.

--- a/docs/networkGame/player.md
+++ b/docs/networkGame/player.md
@@ -5,6 +5,15 @@ sidebar_position: 2
 
 # Player network management
 
+:::tip[New here? Read the overview first]
+**[How DyingStar networking works](./intro.md)** explains the whole system in plain language, with
+no code. This page is the hands-on guide for the parts that are specific to the player.
+:::
+
+In plain terms: your character is just another networked object — the difference is that *your*
+game also sends **your inputs** (move, jump, press E) up to the server, which decides the result
+and sends it back to everyone.
+
 The player and every generic prop replicate their state to nearby players through the **same**
 mechanism: the game server sends property updates to Horizon, which keeps an authoritative copy
 of each object and forwards the changes to the clients in range.
@@ -73,3 +82,25 @@ func client_channel_data_update(data: Dictionary) -> void:
 if data.has("health"):
 health = data["health"]
 ```
+
+## Server-authoritative interaction (carry example)
+
+Interaction must be decided by the **server**, never trusted from the client — this is an MMO,
+so the server is the anti-cheat authority. The client may show prompts and predictions for
+instant feedback, but the server re-checks everything before acting.
+
+The carry/pickup illustrates the pattern:
+
+- **Reachability + line of sight** are checked **on the server** (it owns the collisions; the
+  client often has none — e.g. server-only terrain). Before granting a pickup the server
+  raycasts from the player's eye to the prop and refuses if any solid body (a wall/building)
+  is in between, so a thin wall can't be exploited to grab through it. The prop itself and its
+  holder (a vehicle bed, a depot, the ground it rests on) are ignored, so taking a crate out
+  of a bed still works. Very small or fragmented props (e.g. a mining rock) are **exempt** from
+  the line-of-sight check: their thin, broken-up colliders made the ray report a false block, so
+  the server skips the wall test for them and relies on reach alone.
+- **The prompt is server-driven.** The server computes `[E] Carry` / `[E] Drop` (reachable, in
+  line of sight, not already carried by someone else) and replicates it to the owning client,
+  which only displays it — the client never decides the prompt itself.
+- Because that prompt is a replicated player property, it must be whitelisted in
+  `player_def.json` (see the warning above) or Horizon drops it.

--- a/docs/networkGame/props.md
+++ b/docs/networkGame/props.md
@@ -5,6 +5,15 @@ sidebar_position: 3
 
 # Props network management
 
+:::tip[New here? Read the overview first]
+**[How DyingStar networking works](./intro.md)** explains the whole system in plain language, with
+no code — start there if words like *replicate*, *Horizon* or *GORC* are new to you. This page is
+the hands-on guide for people who write props.
+:::
+
+In plain terms: a "prop" is any object in the world — a box, a rock, a building, a vehicle. This
+page shows how to make one that **every player sees** and that **stays in sync** for everyone.
+
 Generic props replicate their state through the same mechanism as the player: the game server
 sends property updates to Horizon, which keeps an authoritative copy and forwards them to the
 clients in range. This page also covers the **player's replication** to other clients — the
@@ -30,10 +39,12 @@ prop needs:
 
 - the replication signals (`hs_server_prop_update` / `hs_server_prop_delete`),
 - the `uuid` / `type_name` / position state,
-- server -> client replication every physics frame via `PropNet.server_tick(self)` —
-  including **following the carrier** while the prop is held,
-- the `"carriable"` group and the carry contract (`interact()` / `set_carried()`, which also
-  disables the prop's collision while it is carried),
+- server -> client replication driven by `PropNet.server_tick(self)`, which sends an update
+  **only when** the prop's local position/rotation/parent actually changes (not every frame); a
+  held or loaded prop does **not** re-announce itself — Horizon rebuilds its world position from
+  its parent (see [Carriables](#carriables-carry--drop)),
+- the `"carriable"` group and the carry contract (`interact()` / `set_carried()` — see
+  [Carriables](#carriables-carry--drop)),
 - reparenting and delete-on-exit.
 
 So a carriable prop is just:
@@ -51,6 +62,14 @@ Build the scene (a body + collision shape + mesh), attach the script, and declar
 `<type>_def.json` (see [Replication definition files](#replication-definition-files)). Done —
 no boilerplate to copy.
 
+:::note[Set the prop's mass]
+Set the `RigidBody3D` **Mass** on your prop's scene (Inspector). It is the prop's weight
+everywhere in the game — its physics behaviour, and what a vehicle bed counts as cargo load
+(see [Cargo — loading the bed](./vehicles.md)). A prop left at the default **1 kg** feels
+weightless and barely registers as cargo, so give it a realistic value. (The mining rock sets
+this per-piece from its volume instead of a fixed value.)
+:::
+
 ### Complex props
 
 A prop with special behaviour may stay a standalone script (extending whatever body it needs)
@@ -58,6 +77,70 @@ and implement the contract itself, but it should still call `PropNet.server_tick
 its `_physics_process` so replication and carry-follow stay consistent. Example: the mining
 rock (`rock_mining.gd`) is custom because it fractures, and only a **fully-fractured ore
 piece** is carriable (it overrides `interact()` for that) — a whole rock is not carriable.
+
+## Positions are relative to a parent
+
+A prop never stores its absolute world position. It stores a **local** position plus a
+`parent_id` — the uuid of the object it is attached to (a planet, a city, a vehicle, the player
+carrying it…). Horizon rebuilds the real world position by walking the chain
+(`world = parent's world + local`). See [the introduction](./intro.md#the-backbone-parents-parent_id)
+for the why; this section is what it means when you write a prop.
+
+Three rules follow from it:
+
+- **A child of a moving thing does not re-announce its position.** When a truck drives, the box
+  in its bed keeps the *same* local position, so `PropNet.server_tick` sends nothing — and that
+  is correct. Horizon moves the box because its **parent** moved. Re-sending the box every frame
+  "to keep it fresh" is wrong: it floods the network for no reason (it was a real cause of the
+  game freezing under load).
+
+- **Re-parenting is a server decision.** Only the game server changes a prop's (or a player's)
+  parent and replicates the new `parent_id`; clients **apply** it, they never decide it. On the
+  client, after applying a new parent to a node, call `reset_physics_interpolation()` on it, or
+  it will visually slide in from its previous world position.
+
+- **Deleting a parent? Re-attach its children first.** Before freeing a prop that has replicated
+  children (a warehouse full of crates, a vehicle with cargo, a rock about to break apart),
+  move those children up to the deleted prop's own parent. Otherwise they are left pointing at
+  an object that no longer exists, their world position becomes wrong, and they turn into
+  collision-less **ghosts** on the other clients.
+
+:::tip[Only replicate what changed]
+`PropNet.server_tick` compares the prop's position/rotation/parent to the last values it sent
+and emits **only on a real change** — and, for multi-field objects like a vehicle, only the
+fields that changed. When you write your own replication, do the same: never send a full
+snapshot every frame. A lost message is solved by reliable change-detection, not by re-sending
+"just in case".
+:::
+
+## Carriables (carry / drop)
+
+Any prop in the `"carriable"` group can be picked up. The flow is **server-authoritative**: the
+client only aims, the server decides.
+
+- **Aiming** — the client casts its interact ray (areas only) and sends the `uuid` it looks at.
+  Hands free, it shows `[E] Carry` when the target's `interact()` allows it; while holding
+  something it shows `[E] Drop`.
+- **Pick up** (server) — the prop is frozen, parented to the player and marked carried
+  (`set_carried(true)`). Its `parent_id` becomes the player, so Horizon keeps its GORC global
+  fresh by recomputing it from the carrier — the prop follows **without** re-sending its
+  transform every frame (`PropNet.server_tick` emits only on a real change).
+- **Drop** (server) — the prop is un-frozen, reparented back to the world, and `set_carried(false)`.
+  Dropped **while standing in a vehicle bed**, it is loaded onto that vehicle instead (see
+  [Vehicles → Cargo bed](./vehicles.md#cargo--loading-the-bed)).
+
+`interact(interactor) -> bool` is the gate (default: not already carried; the mining rock also
+requires a fully-fractured piece). `set_carried(bool)` only flips the flag — a carried prop **keeps
+its collision** (it stays solid to the world and to other players); the carrier instead adds an
+`add_collision_exception_with()` so it is not blocked by what it holds (removed on drop), and a held
+prop also ignores every **vehicle** so it can't shove a much heavier truck.
+
+:::note[parent_id is replicated, and only re-applied on change]
+A carriable rides its carrier purely through `parent_id` (the player's, or a vehicle's bed). The
+server replicates `parent_id` **only when it actually changes**, and the client reparents only
+then. Delivering that single message reliably is Horizon's job — the prop does not re-send it
+"just in case".
+:::
 
 ## Update properties
 
@@ -223,3 +306,30 @@ helper does both:
 ```
 NetworkOrchestrator.spawn_prop_authoritative(data)  # data must hold "uuid" and "type"
 ```
+
+## Moving or reparenting a prop on the Horizon side (GORC)
+
+Most prop work is done from the game server (Godot). But if you ever **change an object's position
+inside a Horizon plugin** (a move, a drop, a reparent, or recomputing a child's world position),
+there is one rule that is **essential** — getting it wrong silently breaks replication.
+
+:::warning[Always emit GORC zone events when an object moves]
+In a Horizon handler, update an object's position through **`events.update_object_position(...)`**,
+never `gorc_instances.update_object_position(...)` directly.
+
+`gorc_instances.update_object_position` moves the object but **discards the GORC zone entry/exit
+events**. So a player who comes within range of the object's *new* position is never subscribed to
+it and stops receiving its updates — the symptom is an object that "teleported" on the server but
+is stale on a client (e.g. a dropped item glued to the carrier's hand). `events.update_object_position`
+recomputes the zones **and delivers** the entry/exit messages, so nearby clients (re)subscribe.
+
+For a **child** object (e.g. cargo riding in a vehicle bed), compute its world position as
+`parent_global + child_LOCAL` — read the child's **local** position from its zone data, not its
+already-global `position()`, otherwise you double-count the parent's position.
+:::
+
+This is the root cause of the old *"can't drop an item retrieved from a bed"* bug (horizonserver
+`Fix reparent`, `ds_genericprops/src/handlers/update.rs`). It is **not** fixable from the game
+server: re-sending the data more often does nothing if the client was never zone-subscribed — this
+kind of "update never reaches a client after the prop moved" is always a **GORC subscription**
+issue, so it belongs in Horizon, not in the Godot prop.

--- a/docs/networkGame/text_chat.md
+++ b/docs/networkGame/text_chat.md
@@ -86,6 +86,13 @@ user/ACL decision to the small **chat-auth** adapter (`services/chatAuth`). The 
 validates the token's **RS256 signature against Keycloak's JWKS** and checks the issuer —
 the broker never holds the signing key, and key rotation is handled automatically.
 
+:::note[Broker image — maintained fork]
+The jwt broker image is the maintained **`ghcr.io/ajnasz/mosquitto-go-auth`** fork; the original
+`iegomez/mosquitto-go-auth` is unmaintained. The fork keeps the same `go-auth.so` path and
+`auth_opt_*` options, so the mosquitto config is unchanged — only `mosquitto.goauthImage` in the
+chart values points at the fork (pinned to a stable release bundling mosquitto 2.0.x).
+:::
+
 Wiring details that matter:
 
 - The client sends the token as the **MQTT username** (not the password); go-auth forwards

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -5,6 +5,12 @@ sidebar_position: 4
 
 # Adding a vehicle
 
+:::tip[New here? Read the overview first]
+**[How DyingStar networking works](./intro.md)** explains the multiplayer basics in plain
+language. This is a step-by-step build guide — but good news: most of the time a new vehicle is
+just a **scene to assemble**, with little or no new code.
+:::
+
 This guide walks through creating a new drivable vehicle (truck, car, rover…). Vehicles are
 server-authoritative networked props: the game server simulates the physics and replicates the
 state to every client, exactly like the other props (see
@@ -70,14 +76,18 @@ Truck (VehicleBody3D, vehicle.gd)
   **camera eye**, so place it at head height inside the cab, facing forward (the vehicle's local
   `-Z`).
 
-You don't wire anything: the `Vehicle` discovers its seats automatically, and each seat
-auto-detects the player (its collision mask is set in code). Standing in a box shows
-`[E] Drive Seat` / `[E] Passenger Seat` at the crosshair; the driver gets free mouse look while
-driving and exits with **Y**.
+You don't wire anything: the `Vehicle` discovers its seats automatically. The seat box is
+**passive** — it never monitors. Instead the **player's own detector** is the single monitor that
+reports when it walks into a seat zone. This avoids every seat of every vehicle running a
+broad-phase overlap test each physics frame, and it works identically on client and server.
+Standing in a box shows `[E] Drive Seat` / `[E] Passenger Seat` at the crosshair; a taken driver
+seat shows `Driver seat taken` instead. The driver gets free mouse look while driving and exits
+with **Y**; the prompt is hidden while seated, and on exit you are dropped beside the seat you used.
 
 :::tip[Seats are server-authoritative]
-A seat refuses a second occupant. The driver/passenger logic lives in the **networked** path, so
-test seats in the game (F5), not the standalone bench.
+A seat refuses a second occupant, and if a seated player disconnects the server frees their seat
+automatically. The driver/passenger logic lives in the **networked** path, so test seats in the
+game (F5), not the standalone bench.
 :::
 
 ## 4. Configure the powertrain
@@ -111,8 +121,9 @@ A vehicle only replicates if the network layer knows it:
 
 2. **Replication definition** — vehicles use the `vehicle` prop type, defined in
    `horizonserver/ds_genericprops/props/vehicle_def.json` (whitelisting `position`, `rotation`,
-   `scenename`, `parent_id`, `pilot_uuid`, `steering`). If you reuse the `vehicle` type, there is
-   nothing to add. A brand-new type needs its own `<type>_def.json` — see
+   `scenename`, `parent_id`, `pilot_uuid`, `steering`, `speed`, `cargo_mass`, `handbrake`, `mass`,
+   `headlights`). If you reuse the `vehicle` type, there is nothing to add. A brand-new type needs
+   its own `<type>_def.json` — see
    [Replication definition files](./props.md#replication-definition-files).
 
 :::warning[Rebuild Horizon after touching a def]
@@ -129,6 +140,104 @@ the def and **rebuild Horizon**.
   driver or passenger, drive, **Y** to leave. This is the only place seats and passengers are
   faithful.
 
+## Cargo — loading the bed
+
+Two **designer-placed** zones drive cargo (no per-vehicle code):
+
+- **`cargo_bay`** — where cargo *sits*. Tune it via the **Cargo** export group (`cargo_bay_size`,
+  `cargo_bay_offset`, `max_payload`, `overload_immobilize`). It is also the passive zone the player's
+  detector overlaps to count their weight while standing in the bed.
+- **`Cargo_loading_zone`** — where dropping is *allowed to load* (it sticks). Add a `CollisionShape3D`
+  with a `BoxShape3D` named `Cargo_loading_zone` (or assign it to the `Vehicle`'s **Cargo loading
+  zone** export), sized a bit larger than the bay so reaching over the wall counts. Its physics
+  collision is turned off at runtime — it is only a zone marker. If unset, the `cargo_bay` box is
+  used as a fallback.
+
+The load counts toward `max_payload`, the overload limiter shown on the dashboard.
+
+- **Loading** — carry a prop (a crate, a mined rock) and **drop it inside the loading zone** —
+  whether you stand in the bed *or* reach over from outside; the zone (not your position) decides. The
+  `[E]` prompt reads **`[E] Cargo`** when dropping would load it (it sticks) and **`[E] Drop`**
+  otherwise. The carrier hands it to the truck: the prop is frozen, parented to the vehicle so it
+  rides along, and its mass is folded into the load. The bed never polls — loading happens on drop.
+- **Placed in the bay** — a loaded item is tucked **entirely inside** the `cargo_bay` (using its real
+  collision bounds, so any size or off-centre pivot fits) and rested on the bed floor, even when
+  dropped from far / over the rim.
+- **A held prop passes through vehicles** while carried, so a held box can't shove or flip a much
+  heavier truck — you load by dropping, not by ramming.
+- **Retrieve** — aim at a loaded item and press **E** (`[E] Carry`); it leaves the load and goes
+  into your hands, like any [carriable](./props.md#carriables-carry--drop).
+- **What counts as load**:
+  - the props locked in the bed — each prop's weight is its `RigidBody` **mass**;
+  - **on-foot players** standing in the bed (their body mass), **plus whatever they hold** in their
+    hands.
+- **A mining rock's mass scales with its size**: a whole rock keeps the mass set on its scene
+  `RigidBody` (the GameDesigner value); a cut piece weighs that scaled by its volume ratio (a half
+  ≈ half, a quarter ≈ a quarter), so smaller pieces load the bed less.
+- Over `max_payload` the HUD shows `OVERLOADED`; past `max_payload × overload_immobilize` the
+  vehicle won't move. Another **vehicle** is never loaded as cargo (no swallowing a truck with a
+  truck).
+- **Rollover** — if the vehicle tips past `cargo_unlock_tilt_deg` (default 65°), the bed unlocks and
+  spills its whole load (GDD: the lock releases past a certain inclination).
+
+:::note[Riding a moving bed]
+Standing in the bed adds the weight, but **walking** in a *moving* bed (riding it on foot) is not
+supported yet — it needs client-side prediction. A moving truck currently leaves a walker behind.
+:::
+
+### How the load rides the truck (freeze mode)
+
+A loaded crate must follow the truck **rigidly** — and it is a `RigidBody3D`, which the physics engine
+places in **global** space, *not* by inheriting its parent's transform. So parenting a crate under the
+truck is **not enough**; how it is frozen matters.
+
+:::warning[Use FREEZE_MODE_KINEMATIC for a body riding a moving parent — never STATIC]
+A frozen `RigidBody3D` has two modes:
+
+- **`FREEZE_MODE_STATIC`** (the default for a frozen body) behaves like a `StaticBody`: the physics
+  server keeps **rewriting its world transform every physics frame**. Under a moving parent it stays
+  put in the world while the truck drives off — the *"cargo left behind at speed"* bug.
+- **`FREEZE_MODE_KINEMATIC`** is *animatable*: the body **follows its node's transform**
+  (`parent_global × local`), so as the truck moves, the crate rides with it.
+
+The crate is set **KINEMATIC** on both sides: the server does it when it locks the crate, and each
+client does it for the replica **derived from the parent** — when a prop is reparented under a
+`Vehicle` it switches to KINEMATIC, and back to STATIC when it returns to the world (`PropNet.apply_ride_freeze_mode`). Nothing extra is replicated for this: the client reads it from `parent_id`, which already travels.
+:::
+
+On top of that, two pins keep it perfectly stuck:
+
+- **Server pin** — each physics frame the vehicle re-asserts every locked crate's **constant local
+  pose** in the bed (`_pin_locked_cargo`), so a KINEMATIC body can't drift relative to the moving
+  truck. The replicated local position therefore stays constant.
+- **Client pin** — each render frame the prop re-asserts that same local pose
+  (`PropNet.ride_pin`), so the crate tracks the **render-interpolated** truck without stepping at the
+  physics rate (which would jitter). A direct set, not a lerp.
+
+:::note[Cargo debug envelope]
+Turn on **Settings → General → Cargo debug** to draw a green envelope around every crate that is
+*really* locked in a bed (i.e. reparented under the vehicle). An item merely resting loose in the bed
+gets none — a quick way to tell "stuck" from "just sitting there".
+:::
+
+## Hand brake
+
+The driver toggles a parking **hand brake** with a **long press of Space under 3 km/h** (released by
+throttle). It holds the vehicle still on flat ground and slopes — once stopped it is **frozen** so
+it can't creep — and **stays engaged after the driver leaves**. Shown on the HUD and on the
+dashboard.
+
+## Head lights
+
+Head lights are a **drop-in** like seats: add any **`Light3D`** (e.g. a `SpotLight3D` at the front
+facing the vehicle's local `-Z`) to the group **`vehicle_light`** anywhere under the scene — no
+code. The driver toggles them with **L**; the state is server-authoritative and replicated, so every
+client sees them. Shown on the HUD (`[L] lights`) and on the dashboard. The truck ships with two
+front SpotLights as the example.
+
+`L` is **contextual**: it drives the **head lights** while seated as driver, and the player's
+**flashlight** on foot — the two never fire at once.
+
 ## Dashboard — optional in-cab screen
 
 Show live data (speed, RPM, load…) on a screen in the cab using the generic 3D-screen pattern —
@@ -139,4 +248,40 @@ The **vehicle-specific** part is only the UI script: put `vehicle_dashboard.gd`
 (`VehicleDashboard`) on your UI scene's root. It finds its owning `Vehicle` in the tree and shows
 the generic Vehicle data each frame (speed, RPM, load, overload, powertrain, transmission) — so it
 is reusable by any vehicle, and the Vehicle knows nothing about it. Name the Labels `speed`,
-`RPM`, `Load`, `Overloaded`, `Elec_THerm`, `Transmission` (or adjust them in the script).
+`RPM`, `Load`, `Overloaded`, `Elec_THerm`, `Transmission`, `hanbreak`, `Light` (or adjust them in
+the script).
+
+## Rear-view camera & mirrors
+
+A live camera feed on an in-cab screen — a **drop-in** (`scenes/vehicles/rear_camera.tscn`),
+reusable and **client-only** (no render on the headless server). Use it for a reversing camera and
+for side / rear-view mirrors (the GDD allows "mirrors **or** relayed cameras"). Godot has no cheap
+real reflective surface, so a mirror is just a camera too.
+
+**Setup** (no code):
+
+1. Instance `rear_camera.tscn` under the vehicle.
+2. `RearCamera` **is** a Camera3D — place and frame it in the editor (gizmo / **Preview**), at the
+   back looking behind (or at a side mirror, looking back/outward). It never renders to the player's
+   view; a twin camera inside its `SubViewport` (sharing the main `world_3d`) copies its pose + fov
+   and renders the feed.
+3. Add a screen surface — a `MeshInstance3D` with a **`QuadMesh`** (clean `0..1` UVs) — in the cab
+   and set it as the `RearCamera`'s **`screen`**. The feed material is applied at runtime and is
+   **one-sided** (shows only on the quad's front face). If a screen is blank, the quad faces the
+   wrong way — tick **Flip Faces** on its mesh or rotate it 180°. (Flip Faces only changes which side
+   is visible; it does **not** flip the image left/right — that is the `mirror` flag below.)
+4. **`mirror`**: off = a reversing camera (true view); on = a mirror (reverses left/right).
+5. **`resolution`**: match its aspect to the screen quad to avoid stretching.
+6. **`max_distance`** / **`refresh_hz`**: see Performance below.
+
+:::warning[Performance — each feed is a second full render]
+Each `RearCamera` renders the whole world again, so a rear cam + two mirrors = three extra renders.
+Two built-in limiters keep this cheap on weak GPUs (the screens still stay live for everyone):
+
+- **`max_distance`** — beyond this distance from the viewer the feed stops rendering (keeps its last
+  image; it is unreadable from afar anyway). `0` disables the distance cull.
+- **`refresh_hz`** — how many times per second the feed re-renders (default 20, not the full frame
+  rate). `0` renders every frame.
+
+Also keep `resolution` small.
+:::

--- a/docs/uiux/controls_shortcuts.md
+++ b/docs/uiux/controls_shortcuts.md
@@ -1,0 +1,65 @@
+---
+title: Controls & shortcuts
+sidebar_position: 2
+---
+
+# Controls & shortcuts
+
+Every player key is an **InputMap action**, so it shows up — and can be rebound — in
+**Settings → Controls**. The keybind menu (`ui/menu_config/menu_config.gd`) builds its list
+automatically from `InputMap.get_actions()` and saves the player's choices to
+`user://inputs.map`. There is **no hard-coded key** in gameplay code: inputs are read with
+`event.is_action_pressed("…")` / `Input.is_action_pressed("…")`.
+
+## Main shortcuts (default keys)
+
+Several keys are **contextual** — the same key does one thing on foot and another in a vehicle.
+
+| Default | Action | On foot | Driving a vehicle |
+|---|---|---|---|
+| **E** | `action` | Pick up / drop a prop, **enter** a seat | — |
+| **Y** | `exit` | — | Leave the vehicle |
+| **L** | `toggle_flashlight` / `vehicle_lights` | Torch on/off | Head lights on/off |
+| **Space** | `jump` / `brake` | Jump | Brake — **hold** at low speed = hand brake |
+| **R** | `vehicle_reset` | — | Flip the vehicle upright |
+| **2** | `zapette` | Toggle the admin cleanup tool ("Zapette") | (same) |
+
+Movement (`move_forward/back/left/right`), `sprint`, `crouch`, `interact`, mining
+(`toggle_tool`, `aim`, `perforate`), chat (`toggle_chat`, `write_in_chat`) and `pause` are
+actions too — see the full list (and rebind them) in **Settings → Controls**.
+
+:::note[Cargo retrieval & lights]
+A crate in a vehicle bed is grabbed with **E** (the carry prompt shows `[E] Carry`). On the
+in-cab HUD the active shortcuts are listed live (e.g. `[L] lights`, `[Space] brake`).
+:::
+
+## Chat
+
+The message log is **visible by default**; **F12** (`toggle_chat`) hides/shows the whole
+panel. The input bar (channel selector + text field) stays hidden until you write.
+
+To write, press **Enter** (`write_in_chat`): the input bar appears; press **Enter** again
+to send the message and close it. **Escape** (or a mouse click) closes the input without
+sending — Escape here cancels typing rather than opening the pause menu.
+
+While typing, **Tab** cycles between the channels you can post to (today only the global
+channel — group/alliance/region come later). Tab and Escape here are fixed text-field keys,
+like in any chat box, so — unlike `toggle_chat` and `write_in_chat` — they are **not** listed
+in Settings → Controls and cannot be rebound.
+
+## Adding a shortcut (for developers)
+
+**Always add a new key as an InputMap action — never a raw keycode.** A raw
+`event.keycode == KEY_X` is invisible to the settings menu and can't be rebound.
+
+1. Add the action in **Project Settings → Input Map** (or `project.godot` `[input]`), with a
+   default key. Name it readably — the menu label is the action name upper-cased with `_` → spaces.
+2. Read it with `event.is_action_pressed("my_action")` (events) or
+   `Input.is_action_pressed("my_action")` (polling).
+
+It then appears in **Settings → Controls** and is rebindable + persisted, with zero menu code.
+
+:::tip[Exception: dev/bench tools]
+Bench and debug-only keys (e.g. the test bench's `T`/`N`, `F4`, `F10`) may stay raw keycodes —
+they are developer tools, not part of the player's control settings.
+:::

--- a/docs/vFX/minerals.md
+++ b/docs/vFX/minerals.md
@@ -96,6 +96,13 @@ So one texture set feeds **two** outputs — keep both in the mineral's folder:
 
 ## Notes & gotchas
 
+:::note[A rock's mass is a rock property, not a mineral one]
+The `MineralDef` is **look only**. A mining rock's **mass** (its weight as truck cargo) is a
+rock-physics property: it comes from the `RigidBody` mass set on the rock scene (the GameDesigner
+value), scaled by each cut piece's **volume** — a half weighs ~half, a quarter ~a quarter. See
+[Cargo — loading the bed](../networkGame/vehicles.md). Swapping the mineral never changes it.
+:::
+
 :::caution[A metal shows its reflection, not its texture]
 With `metallic = 1` the surface displays the **reflected environment**, not the albedo: under a
 **blue sky** it reads blue-grey, in the **dark** it reads black — it only looks gold with a


### PR DESCRIPTION
Consolidates the network/vehicle/controls documentation into a **single** PR. Replaces and closes #44, #41, #42, #43 (and the controls-shortcuts work). Built locally with `npm run build` (passes, no broken links).

## Goal
Make the docs understandable by **non-network developers — and even non-developers** for the conceptual parts, while staying a precise hands-on guide for contributors. Also fixes statements that became wrong after the network-layer rework on `develop` (DyingStar-game `6bd7468`, horizon `update.rs`).

## What's inside

**`networkGame/intro.md` (was empty) — plain-language overview, no code**
- The one rule (server decides, client shows) and the four actors (game server / Horizon / GORC / client) with an analogy.
- Why interest management (GORC) exists; replication definition files in plain terms.
- The backbone: `parent_id` (positions are local to a parent; Horizon rebuilds world positions; a child of a moving frame rides for free).
- The life of one update + six golden rules.

**`networkGame/props.md`**
- Fix the now-false *"replication every physics frame / following the carrier"* — replication is **change-detected**; a held/loaded prop does not re-announce itself.
- New **"Positions are relative to a parent"** section: local positions, **server-authoritative reparenting** (`reset_physics_interpolation()` after), **reparent children before deleting a parent** (avoids ghosts), "only replicate what changed".
- Carriables (carry/drop), set the prop's mass, Horizon-side GORC reparent rule (`events.update_object_position`).

**`networkGame/player.md`** — server-authoritative interaction (carry line-of-sight + server-driven prompt), mining-rock LOS exemption.

**`networkGame/vehicles.md`** — cargo bed, hand brake, head lights, rear-view camera, player-monitored seats, freeze-mode (KINEMATIC) bed riding.

**`uiux/controls_shortcuts.md`** — Controls & shortcuts page. Every key is an InputMap action (rebindable in Settings → Controls); default keys and chat behaviour (F12 / Enter / Tab / Escape) verified against the game code.

**`networkGame/text_chat.md`** — jwt broker image note. **`vFX/minerals.md`** — rock mass note.

## Accessibility
`intro.md` reads with zero code; each contributor page opens with a plain-language summary and a pointer to the overview.