### PR TITLE
docs(vehicles): hand brake (spawn parked, no freeze) + steering-wheel spin axis

### DIFF
--- a/docs/creativeConcept/vehicle_models.md
+++ b/docs/creativeConcept/vehicle_models.md
@@ -69,6 +69,19 @@ the air:
 :::tip Apply your transforms
 Before export, **`Ctrl+A → All Transforms`** on every object (bakes scale/rotation/position). A wrong
 or unapplied scale is the #1 cause of parts arriving twisted or offset in the game.
+
+**One exception — the steering wheel of an angled column** (see below): apply Location + Scale, but
+**keep its Rotation** (don't bake it), so its spin axis stays a clean local axis.
+:::
+
+:::tip The steering wheel — keep the disc flat, tilt with the object
+The game spins the steering wheel around one of its **local axes**, so that axis must stay aligned with
+the **column**. Model the disc **flat** (its face in the local plane, normal along **local Z**), then
+angle the wheel using the **object's Rotation** (e.g. `35°` on X for a leaning column) — and **do NOT
+apply** that rotation (`Ctrl+A`), or the tilt bakes into the geometry and the local axis no longer
+follows the column. Check the **N-panel → Item → Rotation** shows your angle (not `0`). The dev then
+sets the spin axis in Godot — usually **`(0, 1, 0)`**, because the glTF export turns Blender's Z-up into
+Godot's Y-up so the disc normal (Blender `+Z`) becomes Godot `+Y`.
 :::
 
 ## Separating a part into its own object (`P`)

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -370,10 +370,12 @@ gets none — a quick way to tell "stuck" from "just sitting there".
 
 ## Hand brake
 
-The driver toggles a parking **hand brake** with a **long press of Space under 3 km/h** (released by
-throttle). It holds the vehicle still on flat ground and slopes — once stopped it is **frozen** so
-it can't creep — and **stays engaged after the driver leaves**. Shown on the HUD and on the
-dashboard.
+Vehicles **spawn with the hand brake engaged** (parked), and the driver toggles it with a **long press
+of Space under 3 km/h** (released by throttle). It holds the vehicle still on flat ground and slopes by
+**braking the wheels and cancelling drift** — **not** by freezing the body (freezing a `VehicleBody3D`
+collapses the wheel suspension, so the wheels sink into the ground). It **stays engaged after the
+driver leaves**. A moving vehicle left with **no driver and no hand brake** coasts to a stop on its own
+(it never keeps driving off). Shown on the HUD and on the dashboard.
 
 ## Head lights
 

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -200,8 +200,18 @@ steers. Tune in the **Wheels** + **Real 3D model** groups: `wheel_radius`, `susp
 
 ### Steering wheel
 A mesh named `steering_wheel` turns with the steering angle — cosmetic, it reuses the already-
-replicated `steering` (nothing new on the wire). Tune `steering_wheel_axis` (column axis) and
-`steering_wheel_ratio` (lock-to-lock feel). Absent → no-op.
+replicated `steering` (nothing new on the wire). It spins around **`steering_wheel_axis`** in the mesh's
+own local frame (so a tilted column still turns in-plane); `steering_wheel_ratio` sets the lock-to-lock
+feel. Absent → no-op.
+
+:::warning[The spin axis is usually `(0, 1, 0)`, not `(0, 0, 1)` — Blender Z-up → Godot Y-up]
+The disc's normal (its spin axis) is `+Z` in Blender, but the glTF export converts **Z-up → Y-up**, so
+in Godot that normal becomes local **`+Y`**. So `steering_wheel_axis` is typically **`(0, 1, 0)`** (use
+`(0, -1, 0)` if it spins the wrong way); `(0, 0, 1)` makes it wobble around the vertical instead. For an
+**angled column** this only holds if the tilt lives in the wheel's **object rotation, not baked into the
+geometry** — see the [modeler page](../creativeConcept/vehicle_models.md): keep the disc flat in local
+space, tilt the object, and **don't apply** that rotation.
+:::
 
 ### Doors (server-authoritative) + handles
 **State** — open/close is decided by the **server** and replicated to everyone via the `doors`


### PR DESCRIPTION
## Description

Bring the **Hand brake** section of *Adding a vehicle* in line with the vehicle fixes (PR DyingStar #224):

- Vehicles now **spawn parked** (hand brake engaged).
- The hold is by **braking the wheels + drift-cancel**, **not** by freezing the body — the old doc said "once stopped it is frozen", which is now false (freezing a `VehicleBody3D` collapses the wheel suspension and the wheels sink into the ground).
- A moving vehicle with **no driver and no hand brake** now **coasts to a stop** (it no longer keeps driving off).

Docs build clean (`npm run build`).
