### PR TITLE
docs(interaction): line-of-sight for door handles and carry

### DIFF
--- a/docs/networkGame/props.md
+++ b/docs/networkGame/props.md
@@ -124,7 +124,11 @@ client only aims, the server decides.
 - **Pick up** (server) — the prop is frozen, parented to the player and marked carried
   (`set_carried(true)`). Its `parent_id` becomes the player, so Horizon keeps its GORC global
   fresh by recomputing it from the carrier — the prop follows **without** re-sending its
-  transform every frame (`PropNet.server_tick` emits only on a real change).
+  transform every frame (`PropNet.server_tick` emits only on a real change). The pickup also
+  needs a **clear line of sight**: the server casts a solids ray and the prop must be the **first
+  thing hit** (a wall, or the side of the bed it sits in, blocks it) — so you can't grab through
+  geometry you can't actually see past. The client can't check this (it has no collisions), so it
+  is the server's call.
 - **Drop** (server) — the prop is un-frozen, reparented back to the world, and `set_carried(false)`.
   Dropped **while standing in a vehicle bed**, it is loaded onto that vehicle instead (see
   [Vehicles → Cargo bed](./vehicles.md#cargo--loading-the-bed)).

--- a/docs/networkGame/vehicles.md
+++ b/docs/networkGame/vehicles.md
@@ -221,15 +221,33 @@ with no clip falls back to a code hinge-swing on the mesh named `door_id` (about
 
 **Handles are placed in Godot** (like seats), not in the model. Per door:
 1. Add a **`VehicleDoorHandle`** node (an `Area3D`) under the vehicle, on the door's **visible handle**.
-2. Give it a small **`CollisionShape3D`** there (that's what the player looks at).
+2. Give it **two** small **`CollisionShape3D`** children — one on the door's **exterior** handle, one on
+   the **interior** side (the handle you'd reach when seated). Place each box **just proud of the body
+   surface** (see the sightline note below).
 3. Set its exports:
    - **`Door Id`** — the door's mesh / clip prefix (e.g. `Front_l_door`).
+   - **`Outdoor Shape`** — the exterior box (used when interacting **on foot**). Drag the child in.
+   - **`Indoor Shape`** — the interior box (used when interacting **seated**). Drag the child in.
    - **`Open Angle Deg`** — fallback swing angle (used when the door has no Blender clip).
    - **`Reverse`** — swing the other way (fallback) / play the clip backwards (anim). Two doors that
      should open outward need **opposite** `Reverse`.
 
 The handle sits on the interact layer, so the player **looks at it** and presses **E** to toggle the
 door — no proximity zone, no per-vehicle wiring. Prompt: `[E] Open door` / `[E] Close door`.
+
+:::tip[You can only operate the handle you can actually see]
+The interaction is **server-authoritative** and side-aware, so you can't open a door through the
+bodywork:
+- The **box you aim at** must match your side — the **outdoor** box on foot, the **indoor** box when
+  seated in that vehicle. Aiming at the far-side box (the one you couldn't reach) is ignored.
+- That box must also have a **clear line of sight** — a foreign wall, the terrain or another vehicle
+  in the way blocks it (the vehicle's *own* body doesn't count).
+
+Because a vehicle's collision is a coarse **convex** hull that encloses both boxes, the sightline check
+excludes the vehicle itself; the *side* of the box (outdoor vs indoor) is what distinguishes "I can see
+this handle" from "it's on the far side". So place each box **proud of its surface** and assign the two
+`Shape` exports. Leave them unassigned and the sightline gate is simply skipped (the door opens on look).
+:::
 
 :::tip[The handle rides the door automatically]
 Place each handle where the door's handle is **when the door is shut**. At runtime the code re-parents


### PR DESCRIPTION
## Description

Documents the new **server-authoritative line-of-sight** rules for look-at interactions (game PR: interaction line of sight).

- **Vehicle door handles** (`vehicles.md`): a `VehicleDoorHandle` now takes **two** collision boxes assigned to **`Outdoor Shape`** / **`Indoor Shape`**. The box you aim at must match your side (outdoor on foot, indoor when seated) **and** have a clear sightline; the vehicle's own convex hull is excluded, foreign walls block. Added the authoring steps + a "you can only operate the handle you can actually see" note.
- **Carry** (`props.md`): picking up a prop now requires a clear line of sight — the prop must be the first solid the server ray hits, so you can't grab through a wall or the side of a bed.

Docs-only. Docusaurus build passes with no broken links.